### PR TITLE
Restructure for separate packages for blackswan and web backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ yarn build // From frontend directory
 gcloud app deploy // From frontend directory
 mvn package appengine:deploy // From backend directory
 ```
+Run to deploy a cron job:
+```
+gcloud app deploy cron.yaml
+```
+Run to stop a cron job:
+```
+// Remove content in cron.yaml. 
+gcloud app deploy cron.yaml
+```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ mvn package appengine:deploy // From backend directory
 
 ## Deploy cron jobs
 To view all active cron jobs on GCP: https://pantheon.corp.google.com/appengine/cronjobs?project=greyswan
+
 To deploy a cron job:
 1) Specify cron job details in `cron.yaml` file. 
 2) Deploy the `cron.yaml` file. 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GreySwan
 
-## Config React project
+## Config frontend project
 Run `yarn` in `./frontend` to install dependencies.
 
 ## Run locally
@@ -9,6 +9,12 @@ Run `yarn` in `./frontend` to install dependencies.
 yarn local
 // From backend directory
 mvn appengine:run
+```
+
+## Testing
+```
+// From backend directory
+mvn test
 ```
 
 ## Deploy to gcloud
@@ -23,12 +29,18 @@ yarn build // From frontend directory
 gcloud app deploy // From frontend directory
 mvn package appengine:deploy // From backend directory
 ```
-Run to deploy a cron job:
+
+## Deploy cron jobs
+To view all active cron jobs on GCP: https://pantheon.corp.google.com/appengine/cronjobs?project=greyswan
+To deploy a cron job:
+1) Specify cron job details in `cron.yaml` file. 
+2) Deploy the `cron.yaml` file. 
 ```
 gcloud app deploy cron.yaml
 ```
-Run to stop a cron job:
+To stop a cron job:
+1) Remove cron job content in `cron.yaml`. 
+2) Deploy the `cron.yaml` file with cron job content removed. 
 ```
-// Remove content in cron.yaml. 
 gcloud app deploy cron.yaml
 ```

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.google.backend</groupId>
-  <artifactId>backend</artifactId>
+  <artifactId>greyswan</artifactId>
   <version>1</version>
   <packaging>war</packaging>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -23,6 +23,19 @@
       <version>4.0.1</version>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -3,8 +3,8 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.google.sps</groupId>
-  <artifactId>greyswan</artifactId>
+  <groupId>com.google.backend</groupId>
+  <artifactId>backend</artifactId>
   <version>1</version>
   <packaging>war</packaging>
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -25,6 +25,46 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.80</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-labs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.60</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>11.0.2</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/backend/src/main/java/com/google/backend/servlets/DataServlet.java
+++ b/backend/src/main/java/com/google/backend/servlets/DataServlet.java
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.sps.servlets;
+package com.google.backend.servlets;
 
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
@@ -25,7 +25,6 @@ import javax.servlet.http.HttpServletResponse;
 */
 @WebServlet("/api/v1/test-servlet")
 public class DataServlet extends HttpServlet {
-
  @Override
  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
    response.setContentType("text/html;");

--- a/backend/src/main/java/com/google/backend/servlets/DataServlet.java
+++ b/backend/src/main/java/com/google/backend/servlets/DataServlet.java
@@ -25,9 +25,9 @@ import javax.servlet.http.HttpServletResponse;
 */
 @WebServlet("/api/v1/test-servlet")
 public class DataServlet extends HttpServlet {
- @Override
- public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-   response.setContentType("text/html;");
-   response.getWriter().println("Hello world from data servlet!");
- }
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("text/html;");
+    response.getWriter().println("Hello world from data servlet!");
+  }
 }

--- a/backend/src/main/java/com/google/blackswan/mock/AlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/AlertGenerator.java
@@ -12,23 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.backend.servlets;
+package com.google.blackswan.mock;
 
-import java.io.IOException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import com.google.models.*;
+import java.util.List;
 
-/**
-* Servlet to test if servlet connects to React frontend.
-*/
-@WebServlet("/api/v1/test-servlet")
-public class DataServlet extends HttpServlet {
-  @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("Hello world from data servlet!");
-  }
+/** Alert Generator that takes in an AnomalyGenerator and outputs lists of alerts. */
+public interface AlertGenerator {  
+  List<Alert> getAlerts();
 }

--- a/backend/src/main/java/com/google/blackswan/mock/AnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/AnomalyGenerator.java
@@ -12,23 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.backend.servlets;
+package com.google.blackswan.mock;
 
-import java.io.IOException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import com.google.models.*;
+import java.util.List;
 
-/**
-* Servlet to test if servlet connects to React frontend.
-*/
-@WebServlet("/api/v1/test-servlet")
-public class DataServlet extends HttpServlet {
-  @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("Hello world from data servlet!");
-  }
+/** Anomaly Generator that generates anomalies based on data provided. */
+public interface AnomalyGenerator {  
+  List<Anomaly> getAnomalies();
 }

--- a/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.blackswan.mock;
+
+import com.google.models.*;
+import java.util.*;
+
+/** Generate list of dummy alerts. Supposed to analyze list of anomalies and create different alerts. */
+public class DummyAlertGenerator implements AlertGenerator {
+  private static final int SET_ALERT_GROUP_SIZE = 1;
+
+  private List<Alert> alerts;
+
+  public DummyAlertGenerator(AnomalyGenerator anomalyGenerator) {
+    alerts = new ArrayList<Alert>();
+    for (int k = 0; k < SET_ALERT_GROUP_SIZE; k++) {
+      alerts.add(new Alert(Timestamp.getDummyTimestamp(k), anomalyGenerator.getAnomalies(), 
+        Alert.StatusType.UNRESOLVED));
+    }
+  }
+
+  public List<Alert> getAlerts() {
+    return alerts;
+  }
+}

--- a/backend/src/main/java/com/google/blackswan/mock/DummyAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyAnomalyGenerator.java
@@ -12,23 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.google.backend.servlets;
+package com.google.blackswan.mock;
 
-import java.io.IOException;
-import javax.servlet.annotation.WebServlet;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import com.google.models.*;
+import java.util.*;
 
-/**
-* Servlet to test if servlet connects to React frontend.
-*/
-@WebServlet("/api/v1/test-servlet")
-public class DataServlet extends HttpServlet {
-  @Override
-  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    response.setContentType("text/html;");
-    response.getWriter().println("Hello world from data servlet!");
+/** Generate list of hard-coded dummy anomalies. */
+public class DummyAnomalyGenerator implements AnomalyGenerator {
+  private static final int SET_ANOMALY_GROUP_SIZE = 5;
+
+  private List<Anomaly> anomalies;
+
+  public DummyAnomalyGenerator() {
+    anomalies = new ArrayList<Anomaly>();
+    for (int k = 0; k < SET_ANOMALY_GROUP_SIZE; k++) {
+      anomalies.add(Anomaly.getDummyAnomaly());
+    }
+  }
+
+  public List<Anomaly> getAnomalies() {
+    return anomalies;
   }
 }

--- a/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
+++ b/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
@@ -30,7 +30,11 @@ public class CronServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // TODO: Update or clean up log message. 
     log.info("Cron job ran.");
-    response.setStatus(200); 
+
+    // TODO: Logic for cron job to run blackswan mock. (#13)
+
+    response.setStatus(HttpServletResponse.SC_ACCEPTED); 
   }
 }

--- a/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
+++ b/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
@@ -20,9 +20,15 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.logging.Logger;
+import com.google.blackswan.mock.*;
+import com.google.models.*;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import java.util.*;
 
 /**
-* Servlet to test if cron job runs.
+* Servlet to run cron job that generates Alerts to store in the datastore.
 */
 @WebServlet("/blackswan/test")
 public class CronServlet extends HttpServlet {
@@ -32,9 +38,19 @@ public class CronServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     // TODO: Update or clean up log message. 
     log.info("Cron job ran.");
-
+    
     // TODO: Logic for cron job to run blackswan mock. (#13)
-
+    storeAlertInDatastore();
+    
     response.setStatus(HttpServletResponse.SC_ACCEPTED); 
   }
+
+  /** Temporary method for storing dummy alert into datastore. */
+  private void storeAlertInDatastore() {
+    AlertGenerator testAlertGenerator = new DummyAlertGenerator(new DummyAnomalyGenerator());
+    List<Alert> alerts = testAlertGenerator.getAlerts();
+
+    DatastoreServiceFactory.getDatastoreService().put(alerts.get(0).toEntity());
+  }
+
 }

--- a/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
+++ b/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.blackswan.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.logging.Logger;
+
+/**
+* Servlet to test if cron job runs.
+*/
+@WebServlet("/blackswan/test")
+public class CronServlet extends HttpServlet {
+  private static final Logger log = Logger.getLogger(CronServlet.class.getName());
+  
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    log.info("Cron job ran.");
+    response.setStatus(200); 
+  }
+}

--- a/backend/src/main/java/com/google/models/Alert.java
+++ b/backend/src/main/java/com/google/models/Alert.java
@@ -1,0 +1,104 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.models;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.models.Anomaly;
+import com.google.models.Timestamp;
+import java.util.List;
+import java.util.ArrayList;
+import java.time.format.DateTimeParseException;
+
+/** Store alert-related data. */
+public final class Alert {
+  public static final String ALERT_ENTITY_KIND = "alert";
+  public static final String STATUS_PROPERTY = "status";
+  public static final String ANOMALIES_LIST_PROPERTY = "anomaliesList";
+  public static enum StatusType {
+    RESOLVED,
+    UNRESOLVED
+  };
+
+  private final Timestamp timestampDate;
+  private final List<Anomaly> anomalies;
+  private StatusType status;
+
+  public Alert(Timestamp timestampDate, List<Anomaly> anomalies, StatusType status) {
+    this.timestampDate = timestampDate;
+    this.anomalies = new ArrayList<>(anomalies);
+    this.status = status;
+  }
+
+  public List<Anomaly> getAnomalies() {
+    return anomalies;
+  }
+
+  public Timestamp getTimestamp() {
+    return timestampDate;
+  }
+
+  public StatusType getStatus() {
+    return status;
+  }
+
+  public void setStatus(StatusType status) {
+    this.status = status;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof Alert)) {
+      return false;
+    }
+
+    Alert target = (Alert) o;
+
+    return target.timestampDate.equals(timestampDate) && target.status.equals(status)
+        && target.anomalies.equals(anomalies);
+  }
+
+  public Entity toEntity() {
+    Entity alertEntity = new Entity(ALERT_ENTITY_KIND);
+    alertEntity.setProperty(Timestamp.TIMESTAMP_PROPERTY, timestampDate.toString());
+    alertEntity.setProperty(STATUS_PROPERTY, status.name());
+
+    List<EmbeddedEntity> list = new ArrayList<EmbeddedEntity>();
+    anomalies.forEach(anomaly -> list.add(anomaly.toEmbeddedEntity()));
+
+    alertEntity.setProperty(ANOMALIES_LIST_PROPERTY, list);
+
+    return alertEntity;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static Alert createAlertFromEntity(Entity alertEntity) {
+    List<EmbeddedEntity> listEE = (List<EmbeddedEntity>) alertEntity.getProperty(ANOMALIES_LIST_PROPERTY);
+
+    List<Anomaly> listAnomaly = new ArrayList<Anomaly>();
+    if (listEE != null) {
+      listEE.forEach(embeddedAnomaly -> listAnomaly.add(Anomaly.createAnomalyFromEmbeddedEntity(embeddedAnomaly)));
+    }
+
+    return new Alert(new Timestamp((String) alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY)), 
+        listAnomaly, 
+        StatusType.valueOf((String) alertEntity.getProperty(STATUS_PROPERTY)));
+  }
+
+}

--- a/backend/src/main/java/com/google/models/Anomaly.java
+++ b/backend/src/main/java/com/google/models/Anomaly.java
@@ -1,0 +1,148 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.models;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.models.MetricValue;
+import com.google.models.Timestamp;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import java.util.Map;
+import java.util.HashMap;
+import java.time.format.DateTimeParseException;
+
+/** 
+ * Store anomaly-related data. 
+ * This is an immutable class. 
+ */
+public final class Anomaly {
+  public static final String ANOMALY_ENTITY_KIND = "anomaly";
+  public static final String METRIC_NAME_PROPERTY = "metricName";
+  public static final String DIMENSION_NAME_PROPERTY = "dimensionName";
+  public static final String DATA_POINTS_PROPERTY = "dataPoints";
+
+  private static final String DUMMY_METRIC_NAME = "Sample metric name";
+  private static final String DUMMY_DIMENSION_NAME = "Sample dimension name";
+  private static final Map<Timestamp, MetricValue> DUMMY_DATA_POINTS = ImmutableMap.of( 
+      Timestamp.getDummyTimestamp(1), new MetricValue(1), 
+      Timestamp.getDummyTimestamp(2), new MetricValue(2), 
+      Timestamp.getDummyTimestamp(3), new MetricValue(3));
+  
+  private final Timestamp timestampDate;
+  private final String metricName;
+  private final String dimensionName;
+  private final Map<Timestamp, MetricValue> dataPoints;
+  
+  public Anomaly(Timestamp timestampDate, String metricName, String dimensionName, 
+      Map<Timestamp, MetricValue> dataPoints) {
+    this.timestampDate = timestampDate;
+    this.metricName = metricName;
+    this.dimensionName = dimensionName;
+    this.dataPoints = new HashMap<Timestamp, MetricValue>(dataPoints);
+  }
+
+  public Timestamp getTimestamp() {
+    return timestampDate;
+  }
+
+  public String getMetricName() {
+    return metricName;
+  }
+
+  public String getDimensionName() {
+    return dimensionName;
+  }
+
+  public Map<Timestamp, MetricValue> getDataPoints() {
+    return dataPoints;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof Anomaly)) {
+      return false;
+    }
+
+    Anomaly target = (Anomaly) o;
+
+    return target.timestampDate.equals(timestampDate) && target.metricName.equals(metricName)
+        && target.dimensionName.equals(dimensionName) 
+        && dataPoints.entrySet().stream().allMatch(
+          e -> e.getValue().equals(target.dataPoints.get(e.getKey()))
+        );
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder str = new StringBuilder("");
+    str.append("Timestamp: " + timestampDate + "\n");
+    str.append("Metric Name: " + metricName + "\n");
+    str.append("Dimension Name: " + dimensionName + "\n");
+    str.append("Datapoints: \n");
+    dataPoints.forEach((key, value) -> 
+      str.append(key + ": " + value + "\n")
+    );
+    return str.toString();
+  }
+
+  public static Anomaly getDummyAnomaly() {
+    return new Anomaly(Timestamp.getDummyTimestamp(1), DUMMY_METRIC_NAME, DUMMY_DIMENSION_NAME, 
+        DUMMY_DATA_POINTS);
+  }
+
+  public Entity toEntity() {
+    Entity anomalyEntity = new Entity(ANOMALY_ENTITY_KIND);
+    anomalyEntity.setProperty(Timestamp.TIMESTAMP_PROPERTY, timestampDate.toString());
+    anomalyEntity.setProperty(METRIC_NAME_PROPERTY, metricName);
+    anomalyEntity.setProperty(DIMENSION_NAME_PROPERTY, dimensionName);
+
+    EmbeddedEntity dataPointsEntity = new EmbeddedEntity();
+    dataPoints.forEach((timestamp, metricValue) -> 
+        dataPointsEntity.setProperty(timestamp.toString(), metricValue.getValue()));
+    anomalyEntity.setProperty(DATA_POINTS_PROPERTY, dataPointsEntity);
+
+    return anomalyEntity;
+  }
+
+  /** TODO: Move Entity to Embedded Entity conversion somewhere else that all entity can share. */
+  public EmbeddedEntity toEmbeddedEntity() {
+    Entity anomalyEntity = toEntity();
+    EmbeddedEntity anomalyEmbeddedEntity = new EmbeddedEntity();
+    anomalyEmbeddedEntity.setKey(anomalyEntity.getKey());
+    anomalyEmbeddedEntity.setPropertiesFrom(anomalyEntity);
+    return anomalyEmbeddedEntity;
+  }
+
+  public static Anomaly createAnomalyFromEmbeddedEntity(EmbeddedEntity anomalyEmbeddedEntity) {
+    EmbeddedEntity dataPointsEE = (EmbeddedEntity) anomalyEmbeddedEntity.getProperty(DATA_POINTS_PROPERTY);
+    Map<Timestamp, MetricValue> dataPointsMap = new HashMap<>();
+
+    if (dataPointsEE != null) {
+      for (String key : dataPointsEE.getProperties().keySet()) {
+        dataPointsMap.put(new Timestamp(key), new MetricValue((int) dataPointsEE.getProperty(key)));
+      }
+    }
+
+    return new Anomaly(new Timestamp((String) anomalyEmbeddedEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY)), 
+        (String) anomalyEmbeddedEntity.getProperty(METRIC_NAME_PROPERTY),
+        (String) anomalyEmbeddedEntity.getProperty(DIMENSION_NAME_PROPERTY),
+        dataPointsMap);
+  }
+
+}

--- a/backend/src/main/java/com/google/models/MetricValue.java
+++ b/backend/src/main/java/com/google/models/MetricValue.java
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.models;
+
+/** 
+ * Wrapper for a metric value.
+ * This is an immutable class. 
+ * TODO: Make metric value work for double, floats, etc.  
+ */
+public final class MetricValue {
+  
+  private final int value;
+
+  public MetricValue(int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @Override
+   public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof MetricValue)) {
+      return false;
+    }
+
+    MetricValue target = (MetricValue) o;
+
+    return target.value == value;
+  }
+
+}

--- a/backend/src/main/java/com/google/models/Timestamp.java
+++ b/backend/src/main/java/com/google/models/Timestamp.java
@@ -1,0 +1,89 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.models;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.lang.Math;
+
+/**
+ * Wrapper for LocalDate object with day, month, year fields. This class is immutable. 
+ * Accepts format in yyyy-MM-dd or yyyy-M-d or yyyy-MM-d or yyyy-M-dd, but prints format in yyyy-MM-dd.
+ */
+public final class Timestamp {
+  public static final String TIMESTAMP_PROPERTY = "timestamp";
+  private static final String EXCEPTION_MESSAGE = "Invalid string format.";
+  private static final int NUM_OF_MONTHS = 12;
+  private static final DateTimeFormatter DATE_FORMATTER = new DateTimeFormatterBuilder()
+                                                    .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                                                    .appendOptional(DateTimeFormatter.ofPattern("yyyy-M-d"))
+                                                    .appendOptional(DateTimeFormatter.ofPattern("yyyy-MM-d"))
+                                                    .appendOptional(DateTimeFormatter.ofPattern("yyyy-M-dd"))
+                                                    .toFormatter();
+
+  private final LocalDate date;
+ 
+  public Timestamp(int day, int month, int year) {
+    date = LocalDate.of(year, month, day);
+  }
+
+  public Timestamp(String dateString) {
+    date = LocalDate.parse(dateString, DATE_FORMATTER);
+  }
+
+  public int getDay() {
+    return date.getDayOfMonth();
+  }
+
+  public int getMonth() {
+    return date.getMonthValue();
+  }
+
+  public int getYear() {
+    return date.getYear();
+  }
+
+  @Override
+  public String toString() {
+    return date.toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return toString().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+
+    if (!(o instanceof Timestamp)) {
+      return false;
+    }
+
+    Timestamp target = (Timestamp) o;
+
+    return target.date.equals(date);
+  }
+
+  public static Timestamp getDummyTimestamp(int random) {
+    return new Timestamp(1, Math.abs(random) % NUM_OF_MONTHS + 1, 2000);
+  }
+
+}

--- a/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
@@ -27,8 +27,8 @@ public class DataServletTest {
   @Mock HttpServletRequest request;
   @Mock HttpServletResponse response;
 
-  private DataServlet dataServlet = new DataServlet();
-  private StringWriter stringWriter = new StringWriter();
+  private static final DataServlet dataServlet = new DataServlet();
+  private static final StringWriter stringWriter = new StringWriter();
 
   @Before
   public void setUp() throws Exception {

--- a/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
@@ -1,0 +1,53 @@
+package com.google.backend.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/** Contain tests for methods in {@link DataServlet} class. */
+@RunWith(JUnit4.class)
+public class DataServletTest {
+  @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
+
+  private DataServlet dataServlet;
+  private StringWriter stringWriter;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    dataServlet = new DataServlet();
+    stringWriter = new StringWriter();
+    when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+  }
+
+  @Test
+  public void testDataServlet_correctResponse() throws IOException, ServletException {
+    dataServlet.doGet(request, response);
+
+    String actual = stringWriter.getBuffer().toString().trim();
+    String expected = "Hello world from data servlet!";
+
+    assertEquals(actual, expected);
+  }
+
+  /** TODO: Add tests for logic of DataServlet once more complicated logic is implemented. */
+
+}

--- a/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/DataServletTest.java
@@ -27,14 +27,12 @@ public class DataServletTest {
   @Mock HttpServletRequest request;
   @Mock HttpServletResponse response;
 
-  private DataServlet dataServlet;
-  private StringWriter stringWriter;
+  private DataServlet dataServlet = new DataServlet();
+  private StringWriter stringWriter = new StringWriter();
 
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
-    dataServlet = new DataServlet();
-    stringWriter = new StringWriter();
     when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
   }
 
@@ -42,10 +40,7 @@ public class DataServletTest {
   public void testDataServlet_correctResponse() throws IOException, ServletException {
     dataServlet.doGet(request, response);
 
-    String actual = stringWriter.getBuffer().toString().trim();
-    String expected = "Hello world from data servlet!";
-
-    assertEquals(actual, expected);
+    assertEquals(stringWriter.getBuffer().toString().trim(), "Hello world from data servlet!");
   }
 
   /** TODO: Add tests for logic of DataServlet once more complicated logic is implemented. */

--- a/backend/src/test/java/com/google/blackswan/servlets/CronServletTest.java
+++ b/backend/src/test/java/com/google/blackswan/servlets/CronServletTest.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.util.logging.Logger;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 
 import org.junit.After;
 import org.junit.Before;
@@ -29,11 +30,19 @@ public class CronServletTest {
   @Mock HttpServletResponse response;
 
   private CronServlet cronServlet;
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
   @Before
   public void setUp() throws Exception {
+    helper.setUp();
     MockitoAnnotations.initMocks(this);
     cronServlet = new CronServlet();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
   }
 
   @Test

--- a/backend/src/test/java/com/google/blackswan/servlets/CronServletTest.java
+++ b/backend/src/test/java/com/google/blackswan/servlets/CronServletTest.java
@@ -1,0 +1,48 @@
+package com.google.blackswan.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.logging.Logger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/** Contain tests for methods in the {@link CronServlet} class. */
+@RunWith(JUnit4.class)
+public class CronServletTest {
+  @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
+
+  private CronServlet cronServlet;
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    cronServlet = new CronServlet();
+  }
+
+  @Test
+  public void testCronServletGet_returnStatus() throws IOException, ServletException {
+    cronServlet.doGet(request, response);
+
+    verify(response).setStatus(HttpServletResponse.SC_ACCEPTED);
+  }
+
+  /** TODO: Include tests for other logics of CronServlet once implemented. */
+
+}

--- a/backend/src/test/java/com/google/models/AlertTest.java
+++ b/backend/src/test/java/com/google/models/AlertTest.java
@@ -1,0 +1,115 @@
+package com.google.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import java.util.*;
+import com.google.blackswan.mock.*;
+import java.time.format.DateTimeParseException;
+
+/** Contain tests for methods in {@link Alert} class. */
+@RunWith(JUnit4.class)
+public final class AlertTest {
+  private static final int TIMESTAMP_CONSTANT = 1;
+  private static final AnomalyGenerator dummyAnomalyGenerator = new DummyAnomalyGenerator();
+  private static final LocalServiceTestHelper helper = 
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  private Alert alert;
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+    // TODO: Find out whether it's better to set parameters for Alert as private static variables,
+    //       since they're used later to test getters. 
+    alert = new Alert(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), dummyAnomalyGenerator.getAnomalies(), 
+        Alert.StatusType.UNRESOLVED);
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void getTimestamp_workingGetter() {
+    assertEquals(alert.getTimestamp(), Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT));
+  }
+
+  @Test
+  public void getAnomalies_workingGetter() {
+    // Check to see if List<Anomaly> returned is same as List<Anomaly> used to generate alert.
+    assertEquals(alert.getAnomalies(), dummyAnomalyGenerator.getAnomalies());
+  }
+
+  @Test
+  public void getStatus_workingGetter() {
+    assertEquals(alert.getStatus(), Alert.StatusType.UNRESOLVED);
+  }
+
+  @Test
+  public void setStatus_workingSetter() {
+    alert.setStatus(Alert.StatusType.RESOLVED);
+
+    assertEquals(alert.getStatus(), Alert.StatusType.RESOLVED);
+  }
+
+  @Test
+  public void equals_workingComparator() {
+    Alert sameAlert = new Alert(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), dummyAnomalyGenerator.getAnomalies(), 
+        Alert.StatusType.UNRESOLVED);
+    Alert diffTimeAlert = new Alert(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT + 1), dummyAnomalyGenerator.getAnomalies(), 
+        Alert.StatusType.UNRESOLVED);
+    Alert diffResolveAlert = new Alert(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), dummyAnomalyGenerator.getAnomalies(), 
+        Alert.StatusType.RESOLVED);
+    // TODO: Test equals with Alert object that has different list of anomalies. Currently, dummyAnomalyGenerator can only 
+    //       generate one list of anomalies right now. 
+
+    assertTrue(alert.equals(alert));
+    assertTrue(alert.equals(sameAlert));
+    assertFalse(alert.equals(diffTimeAlert));
+    assertFalse(alert.equals(diffResolveAlert));
+    assertFalse(alert.equals(null));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void toEntity_correctAlertToEntityConversion() {
+    List<Anomaly> anomalyList = new ArrayList<Anomaly>();
+
+    Entity alertEntity = alert.toEntity();
+    List<EmbeddedEntity> anomalyEmbeddedList = 
+        (List<EmbeddedEntity>) alertEntity.getProperty(Alert.ANOMALIES_LIST_PROPERTY);
+
+    anomalyEmbeddedList.forEach(
+      embeddedAnomaly -> anomalyList.add(Anomaly.createAnomalyFromEmbeddedEntity(embeddedAnomaly))
+    );
+
+    assertEquals(anomalyList, alert.getAnomalies());
+    assertEquals(alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), alert.getTimestamp().toString());
+    assertEquals(alertEntity.getProperty(Alert.STATUS_PROPERTY), alert.getStatus().name());
+  }
+
+  @Test
+  public void createAlertFromEntity_correctEntityToAlertConversion() {
+    Entity alertEntity = alert.toEntity();
+    Alert convertedAlert = Alert.createAlertFromEntity(alertEntity);
+
+    assertEquals(alert, convertedAlert);
+  }
+
+}

--- a/backend/src/test/java/com/google/models/AnomalyTest.java
+++ b/backend/src/test/java/com/google/models/AnomalyTest.java
@@ -1,0 +1,146 @@
+package com.google.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+/** Contain tests for methods in {@link Anomaly} class. */
+@RunWith(JUnit4.class)
+public final class AnomalyTest {
+  private static final int TIMESTAMP_CONSTANT = 1;
+  private static final String METRIC_NAME = "Sample metric name";
+  private static final String DIMENSION_NAME = "Sample dimension name";
+  private static final Map<Timestamp, MetricValue> DATA_POINTS = ImmutableMap.of( 
+      Timestamp.getDummyTimestamp(1), new MetricValue(1), 
+      Timestamp.getDummyTimestamp(2), new MetricValue(2), 
+      Timestamp.getDummyTimestamp(3), new MetricValue(3));
+  private static final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  private static final Anomaly ANOMALY = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+      METRIC_NAME, DIMENSION_NAME, DATA_POINTS);
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void getTimestamp_workingGetter() {
+    assertEquals(ANOMALY.getTimestamp(), Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT));
+  }
+
+  @Test
+  public void getMetricName_workingGetter() {
+    assertEquals(ANOMALY.getMetricName(), METRIC_NAME);
+  }
+
+  @Test
+  public void getDimensionName_workingGetter() {
+    assertEquals(ANOMALY.getDimensionName(), DIMENSION_NAME);
+  }
+
+  @Test
+  public void getDataPoints_workingGetter() {
+    assertEquals(ANOMALY.getDataPoints(), DATA_POINTS);
+  }
+
+  @Test
+  public void equals_workingComparator() {
+    Anomaly sameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), METRIC_NAME, 
+        DIMENSION_NAME, DATA_POINTS);
+    Anomaly diffTimeAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT + 1), 
+        METRIC_NAME, DIMENSION_NAME, DATA_POINTS);
+    Anomaly diffMetricNameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+        "diff name", DIMENSION_NAME, DATA_POINTS);
+    Anomaly diffDimensionNameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+        METRIC_NAME, "diff name", DATA_POINTS);
+    Anomaly diffDataPointsAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+        METRIC_NAME, "diff name", ImmutableMap.of(Timestamp.getDummyTimestamp(2), new MetricValue(5), 
+                                                  Timestamp.getDummyTimestamp(1), new MetricValue(2), 
+                                                  Timestamp.getDummyTimestamp(3), new MetricValue(3)));
+
+    assertTrue(ANOMALY.equals(ANOMALY));
+    assertTrue(ANOMALY.equals(sameAnomaly));
+    assertFalse(ANOMALY.equals(diffTimeAnomaly));
+    assertFalse(ANOMALY.equals(diffMetricNameAnomaly));
+    assertFalse(ANOMALY.equals(diffDimensionNameAnomaly));
+    assertFalse(ANOMALY.equals(diffDataPointsAnomaly));
+    assertFalse(ANOMALY.equals(null));
+  }
+
+  @Test
+  public void toString_correctConversion() {
+    StringBuilder expectedStr = new StringBuilder("");
+    expectedStr.append("Timestamp: " + ANOMALY.getTimestamp() + "\n");
+    expectedStr.append("Metric Name: " + ANOMALY.getMetricName() + "\n");
+    expectedStr.append("Dimension Name: " + ANOMALY.getDimensionName() + "\n");
+    expectedStr.append("Datapoints: \n");
+    ANOMALY.getDataPoints().forEach((key, value) -> 
+      expectedStr.append(key + ": " + value + "\n")
+    );
+
+    assertEquals(ANOMALY.toString(), expectedStr.toString());
+  }
+
+  @Test
+  public void toEntity_correctAnomalyToEntityConversion() {
+    Entity anomalyEntity = ANOMALY.toEntity();
+    EmbeddedEntity dataPointsEE = (EmbeddedEntity) anomalyEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
+    
+    assertFalse(dataPointsEE.equals(null));
+    assertTrue(embeddedEntityDataPoints_equal(dataPointsEE, ANOMALY.getDataPoints()));
+    assertEquals(anomalyEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), ANOMALY.getTimestamp().toString());
+    assertEquals(anomalyEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY), ANOMALY.getMetricName());
+    assertEquals(anomalyEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY), ANOMALY.getDimensionName());
+  }
+
+  @Test
+  public void toEmbeddedEntity_correctAnomalyToEmbeddedEntityConversion() {
+    EmbeddedEntity anomalyEmbeddedEntity = ANOMALY.toEmbeddedEntity();
+    EmbeddedEntity dataPointsEE = (EmbeddedEntity) anomalyEmbeddedEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
+    
+    assertNotNull(dataPointsEE);
+    assertTrue(embeddedEntityDataPoints_equal(dataPointsEE, ANOMALY.getDataPoints()));
+    assertEquals(anomalyEmbeddedEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), ANOMALY.getTimestamp().toString());
+    assertEquals(anomalyEmbeddedEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY), ANOMALY.getMetricName());
+    assertEquals(anomalyEmbeddedEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY), ANOMALY.getDimensionName());
+  }
+
+  @Test
+  public void createAnomalyFromEmbeddedEntity_correctEmbeddedEntityToAnomalyConversion() {
+    EmbeddedEntity anomalyEmbeddedEntity = ANOMALY.toEmbeddedEntity();
+    Anomaly convertedAnomaly = Anomaly.createAnomalyFromEmbeddedEntity(anomalyEmbeddedEntity);
+
+    assertEquals(convertedAnomaly, ANOMALY);
+  }
+
+
+  private boolean embeddedEntityDataPoints_equal(EmbeddedEntity dataPointsEE, 
+      Map<Timestamp, MetricValue> dataPointsMap) {
+    return dataPointsMap.entrySet().stream().allMatch(
+      e -> e.getValue().getValue() == (int) dataPointsEE.getProperty(e.getKey().toString())
+    );
+  }
+
+}

--- a/backend/src/test/java/com/google/models/MetricValueTest.java
+++ b/backend/src/test/java/com/google/models/MetricValueTest.java
@@ -1,0 +1,39 @@
+package com.google.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+/** Contain tests for methods in {@link MetricValue} class. */
+@RunWith(JUnit4.class)
+public final class MetricValueTest {
+  private static final int VALUE_CONST = 1;
+  private static final MetricValue metricValue = new MetricValue(VALUE_CONST);
+
+  @Test
+  public void getValue_workingGetter() {
+    assertEquals(metricValue.getValue(), VALUE_CONST);
+  }
+
+  @Test
+  public void equals_workingComparator() {
+    MetricValue sameMetricValue = new MetricValue(VALUE_CONST);
+    MetricValue diffMetricValue = new MetricValue(VALUE_CONST + 1);
+
+    assertEquals(metricValue, metricValue);
+    assertEquals(sameMetricValue, metricValue);
+    assertFalse(metricValue.equals(diffMetricValue));
+    assertFalse(metricValue.equals(null));
+  }
+
+  /** TODO: Add tests for toString() and other methods once logic of Metric Value complicates. */
+
+}

--- a/backend/src/test/java/com/google/models/TimestampTest.java
+++ b/backend/src/test/java/com/google/models/TimestampTest.java
@@ -1,0 +1,73 @@
+package com.google.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import java.time.format.DateTimeParseException;
+
+
+/** Contain tests for methods in {@link Timestamp} class. */
+@RunWith(JUnit4.class)
+public final class TimestampTest {
+  private static final int DAY_CONST = 1;
+  private static final int MONTH_CONST = 1;
+  private static final int YEAR_CONST = 2000;
+  private static final Timestamp timestamp = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
+
+  @Test
+  public void constructor_convertStringToDate() {
+    Timestamp stringTimestamp = new Timestamp("2020-12-5");
+    Timestamp stringTimestampPaddedZero = new Timestamp("2020-12-05");
+    Timestamp stringTimestampDiff = new Timestamp("2020-1-01");
+
+    assertEquals(stringTimestamp.getDay(), 5);
+    assertEquals(stringTimestamp.getMonth(), 12);
+    assertEquals(stringTimestamp.getYear(), 2020);
+    assertEquals(stringTimestampPaddedZero.getDay(), 5);
+    assertEquals(stringTimestampPaddedZero.getMonth(), 12);
+    assertEquals(stringTimestampPaddedZero.getYear(), 2020);
+    assertEquals(stringTimestampDiff.getDay(), 1);
+    assertEquals(stringTimestampDiff.getMonth(), 1);
+    assertEquals(stringTimestampDiff.getYear(), 2020);
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void constructor_throwsExceptionForBadFormat_missingDash() {
+    Timestamp stringTimestamp = new Timestamp("202012-5");
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void constructor_throwsExceptionForBadFormat_monthTooLarge() {
+    Timestamp stringTimestamp = new Timestamp("2020-13-5");
+  }
+
+  @Test(expected = DateTimeParseException.class)
+  public void constructor_throwsExceptionForBadFormat_extraDash() {
+    Timestamp stringTimestamp = new Timestamp("2020-13-1-5");
+  }
+
+  @Test
+  public void toString_correctConversion() {
+    assertEquals(timestamp.toString(),
+        YEAR_CONST + "-" + String.format("%02d", MONTH_CONST) + "-" + String.format("%02d", DAY_CONST));
+  }
+
+  @Test
+  public void equals_workingComparator() {
+    Timestamp sameTimestamp = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
+    Timestamp diffTimestamp = new Timestamp(DAY_CONST + 1, MONTH_CONST, YEAR_CONST);
+
+    assertEquals(timestamp, timestamp);
+    assertEquals(sameTimestamp, timestamp);
+    assertFalse(timestamp.equals(diffTimestamp));
+    assertFalse(timestamp.equals(null));
+  }
+
+}

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,5 @@
+# Uncomment lines below and deploy file to run cron job. 
+cron:
+# - description: "cron job test"
+#  url: /blackswan/test
+#  schedule: every 1 mins

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -4,6 +4,9 @@ dispatch:
 # Route the urls that point to the Java backend's API calls
  - url: "*/api/v1/*"
    service: backend
+# Route the urls that point to the Java backend's API calls
+ - url: "*/blackswan/*"
+   service: backend
 # Route all other urls to the React.js frontend
  - url: "*/*"
    service: default

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,10 +1,8 @@
 # Rules for dispatch file...
-# Put specific cases at the top.
 dispatch:
 # Route the urls that point to the Java backend's API calls
  - url: "*/api/v1/*"
    service: backend
-# Route the urls that point to the Java backend's API calls
  - url: "*/blackswan/*"
    service: backend
 # Route all other urls to the React.js frontend


### PR DESCRIPTION
Restructure the directories and package naming scheme so we can have separate packages for blackswan mock and web servlet backend within one maven project. 

The blackswan mock is under package `com.google.blackswan`, and the web servlet backend is under `com.google.backend`. The shared models/classes will be under a separate package, so both blackswan and web backend will have access. 

Cron job for the blackswan mock is also set up in `cron.yaml` and the `dispatch.yaml` file. The endpoint of the blackswan servlet `/blackswan/test` will be called every time the cloud scheduler runs the cron job. 