### PR TITLE
Setup github actions to run frontend and backend tests triggered by push

### DIFF
--- a/.github/workflows/frontendtest.yaml
+++ b/.github/workflows/frontendtest.yaml
@@ -1,0 +1,26 @@
+name: React Continuous Integration
+
+on: [push]
+
+jobs:
+  test:
+    name: Frontend Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install -g yarn
+      working-directory: ./frontend
+    - name: yarn install, build, and test
+      run: |
+        yarn
+        yarn build
+        yarn test
+      working-directory: ./frontend  

--- a/.github/workflows/javatest.yaml
+++ b/.github/workflows/javatest.yaml
@@ -1,0 +1,21 @@
+name: Java Continuous Integration
+
+on: [push]
+
+jobs:
+  test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Maven Package # Install dependencies.
+        working-directory: ./backend
+        run: mvn -B clean package -DskipTests
+      - name: Maven Verify # Run unit tests.
+        working-directory: ./backend
+        run: mvn -B clean verify


### PR DESCRIPTION
On push to any branch in our repo, the github actions specified by the `.yaml` files will trigger the unit tests in backend and frontend to run. 

Note: will integrate automatic deployment in the future once `key.json` is obtained :) 