### PR TITLE
Fetch alerts from Datastore and display in alert management tab

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -59,6 +59,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.6</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>11.0.2</version>

--- a/backend/src/main/java/com/google/backend/servlets/AlertsDataServlet.java
+++ b/backend/src/main/java/com/google/backend/servlets/AlertsDataServlet.java
@@ -35,6 +35,7 @@ public class AlertsDataServlet extends HttpServlet {
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // TODO: only get alerts that the user is subscribed to.
     Query query = new Query(Alert.ALERT_ENTITY_KIND);
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = datastore.prepare(query);

--- a/backend/src/main/java/com/google/backend/servlets/AlertsDataServlet.java
+++ b/backend/src/main/java/com/google/backend/servlets/AlertsDataServlet.java
@@ -1,0 +1,50 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.backend.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.gson.Gson;
+import com.google.models.Alert;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that gets Alert information from the Datastore and returns the JSON. */
+@WebServlet("/api/v1/alerts-data")
+public class AlertsDataServlet extends HttpServlet {
+  
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Query query = new Query(Alert.ALERT_ENTITY_KIND);
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    PreparedQuery results = datastore.prepare(query);
+    List<Alert> alertList = new ArrayList<>();
+
+    for (Entity entity : results.asIterable()) {
+      alertList.add(Alert.createAlertFromEntity(entity));
+    }
+    
+    response.setContentType("application/json;");
+    response.getWriter().println(new Gson().toJson(alertList));
+  }
+}

--- a/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
@@ -1,0 +1,79 @@
+package com.google.backend.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.models.Alert;
+import com.google.models.Anomaly;
+import com.google.models.Timestamp;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.ArrayList;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
+
+/** Contain tests for methods in {@link AlertsDataServlet} class. */
+@RunWith(JUnit4.class)
+public class AlertsDataServletTest {
+  @Mock HttpServletRequest request;
+  @Mock HttpServletResponse response;
+
+  private static final String CONTENT_TYPE = "application/json;";
+  private static final String ENTITY_KIND = Alert.ALERT_ENTITY_KIND;
+
+  private static final AlertsDataServlet alertsDataServlet = new AlertsDataServlet();
+  private final LocalServiceTestHelper helper = new LocalServiceTestHelper(
+    new LocalDatastoreServiceTestConfig());
+  private StringWriter stringWriter = new StringWriter();
+
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+    helper.setUp();
+    when(response.getWriter()).thenReturn(new PrintWriter(stringWriter));
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void doGet_returnAlertEntitiesAsJson() throws IOException, ServletException {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Alert newAlertOne = new Alert(Timestamp.getDummyTimestamp(0), new ArrayList<Anomaly>(), 
+        Alert.StatusType.UNRESOLVED);
+    datastore.put(newAlertOne.toEntity());
+    List<Alert> newAlerts = new ArrayList<>();
+    newAlerts.add(newAlertOne);
+
+    alertsDataServlet.doGet(request, response);
+
+    verify(response).setContentType(CONTENT_TYPE);
+    JsonElement expected = JsonParser.parseString(new Gson().toJson(newAlerts));
+    JsonElement result = JsonParser.parseString(stringWriter.getBuffer().toString().trim());
+    assertEquals(expected, result);
+  }
+}

--- a/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
@@ -9,7 +9,7 @@ import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-
+import com.google.common.collect.ImmutableList; 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -63,16 +62,15 @@ public class AlertsDataServletTest {
   @Test
   public void doGet_returnAlertEntitiesAsJson() throws IOException, ServletException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Alert newAlertOne = new Alert(Timestamp.getDummyTimestamp(0), new ArrayList<Anomaly>(), 
+    Alert newAlert = new Alert(Timestamp.getDummyTimestamp(0), new ArrayList<Anomaly>(), 
         Alert.StatusType.UNRESOLVED);
-    datastore.put(newAlertOne.toEntity());
-    List<Alert> newAlerts = new ArrayList<>();
-    newAlerts.add(newAlertOne);
+    datastore.put(newAlert.toEntity());
 
     alertsDataServlet.doGet(request, response);
 
     verify(response).setContentType(CONTENT_TYPE);
-    JsonElement expected = JsonParser.parseString(new Gson().toJson(newAlerts));
+    JsonElement expected = JsonParser.parseString(
+      new Gson().toJson(ImmutableList.of(newAlert)));
     JsonElement result = JsonParser.parseString(stringWriter.getBuffer().toString().trim());
     assertEquals(expected, result);
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "fontsource-roboto": "^2.2.6",
+    "jest-fetch-mock": "^3.0.3",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -52,18 +52,21 @@ const tabLabels = {
   ALL: 2,
 };
 
-// Helper function to create Date from Timestamp model.
+/*
+ * Helper function to create Date from Timestamp model.
+ */
 const createDate = (timestampDate) => {
   return new Date(
     timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
     .toDateString();
 }
 
-// Data structure explanations:
-// const allAlerts = {id1: {timestamp, # of anomalies}, id2: {timestamp, # of anomalies}, ...};
-// const unresolvedAlerts = [id1, id2, ...] which stores the ids of the alerts in allAlerts
-// const resolvedAlerts = [id3, ...] also stores ids of alerts in allAlerts
-
+/*
+ * Data structure explanation: (can remove later on)
+ * const allAlerts = {id1: {timestamp, # of anomalies}, id2: {timestamp, # of anomalies}, ...};
+ * const unresolvedAlerts = [id1, id2, ...] which stores the ids of the alerts in allAlerts
+ * const resolvedAlerts = [id3, ...] also stores ids of alerts in allAlerts
+ */
 class AlertsContent extends Component {
   constructor(props) {
     super(props);

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -11,6 +11,7 @@ import DoneIcon from '@material-ui/icons/Done';
 import ErrorIcon from '@material-ui/icons/Error';
 import AlertsList from './AlertsList';
 import { convertTimestampToDate } from '../time_utils';
+import { tabLabels, UNRESOLVED_STATUS } from './management_constants';
 
 const styles = ({
   root: {
@@ -47,12 +48,7 @@ TabPanel.propTypes = {
 };
 
 // TODO: create constants file. ref: https://stackoverflow.com/questions/39036457/react-create-constants-file.
-const tabLabels = {
-  UNRESOLVED: 0,
-  RESOLVED: 1,
-  ALL: 2,
-};
-const UNRESOLVED_STATUS = "UNRESOLVED";
+
 
 /*
  * Data structure explanation: (can remove later on)

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -10,6 +10,7 @@ import AllInboxIcon from '@material-ui/icons/AllInbox';
 import DoneIcon from '@material-ui/icons/Done';
 import ErrorIcon from '@material-ui/icons/Error';
 import AlertsList from './AlertsList';
+import { convertTimestampToDate } from '../time_utils';
 
 const styles = ({
   root: {
@@ -51,15 +52,7 @@ const tabLabels = {
   RESOLVED: 1,
   ALL: 2,
 };
-
-/*
- * Helper function to create Date from Timestamp model.
- */
-const createDate = (timestampDate) => {
-  return new Date(
-    timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
-    .toDateString();
-}
+const UNRESOLVED_STATUS = "UNRESOLVED";
 
 /*
  * Data structure explanation: (can remove later on)
@@ -93,10 +86,10 @@ class AlertsContent extends Component {
     alertsResponse.forEach((alert, value) => {
       // TODO: replace value with actual alert ID (received from JSON, e.g. alert.id).
       this.state.allAlerts.set(value, {
-        timestamp: createDate(alert.timestampDate), 
+        timestamp: convertTimestampToDate(alert.timestampDate), 
         anomalies: alert.anomalies.length
       });
-      if (alert.status === "UNRESOLVED") {
+      if (alert.status === UNRESOLVED_STATUS) {
         unresolvedAlerts.push(value);
       } else {
         resolvedAlerts.push(value);

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -87,17 +87,16 @@ class AlertsContent extends Component {
     let resolvedAlerts = [];
 
     const alertsResponse = await fetch('/api/v1/alerts-data').then(response => response.json());
-    alertsResponse.forEach((alert) => {
-      // TODO: replace fakeid with actual alert ID (received from JSON, e.g. alert.id).
-      const fakeid = Math.floor(Math.random() * Math.floor(100));
-      this.state.allAlerts.set(fakeid, {
+    alertsResponse.forEach((alert, value) => {
+      // TODO: replace value with actual alert ID (received from JSON, e.g. alert.id).
+      this.state.allAlerts.set(value, {
         timestamp: createDate(alert.timestampDate), 
         anomalies: alert.anomalies.length
       });
       if (alert.status === "UNRESOLVED") {
-        unresolvedAlerts.push(fakeid);
+        unresolvedAlerts.push(value);
       } else {
-        resolvedAlerts.push(fakeid);
+        resolvedAlerts.push(value);
       }
     });
 

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -47,9 +47,6 @@ TabPanel.propTypes = {
   value: PropTypes.any.isRequired,
 };
 
-// TODO: create constants file. ref: https://stackoverflow.com/questions/39036457/react-create-constants-file.
-
-
 /*
  * Data structure explanation: (can remove later on)
  * const allAlerts = {id1: {timestamp, # of anomalies}, id2: {timestamp, # of anomalies}, ...};

--- a/frontend/src/AlertsManagement/AlertsContent.js
+++ b/frontend/src/AlertsManagement/AlertsContent.js
@@ -45,16 +45,6 @@ TabPanel.propTypes = {
   value: PropTypes.any.isRequired,
 };
 
-// TODO: fetch alerts from backend and save in arrays.
-// Intended plan for reference: 
-// const allAlerts = [id1, id2, id3] where id'x' is the id of AlertX
-// const alertsMap = {id1: <Alert1>, 2: <Alert2>, 3: <Alert3>, ...};
-// const unresolvedAlerts = [0, 1] which stores the indices of the alerts in allAlerts
-// const resolvedAlerts = [2]
-const allAlerts = [0, 1, 2, 3, 4, 5, 6];
-const unresolvedAlerts = [0, 1, 2, 3];
-const resolvedAlerts = [4, 5, 6]
-
 // TODO: create constants file. ref: https://stackoverflow.com/questions/39036457/react-create-constants-file.
 const tabLabels = {
   UNRESOLVED: 0,
@@ -62,13 +52,26 @@ const tabLabels = {
   ALL: 2,
 };
 
+// Helper function to create Date from Timestamp model.
+const createDate = (timestampDate) => {
+  return new Date(
+    timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
+    .toDateString();
+}
+
+// Data structure explanations:
+// const allAlerts = {id1: {timestamp, # of anomalies}, id2: {timestamp, # of anomalies}, ...};
+// const unresolvedAlerts = [id1, id2, ...] which stores the ids of the alerts in allAlerts
+// const resolvedAlerts = [id3, ...] also stores ids of alerts in allAlerts
+
 class AlertsContent extends Component {
   constructor(props) {
     super(props);
     this.state = {
       tab: tabLabels.UNRESOLVED,
-      unchecked: unresolvedAlerts.slice(), 
-      checked: resolvedAlerts.slice(), 
+      allAlerts: new Map(),
+      unchecked: [], 
+      checked: [], 
     };
   }
 
@@ -78,30 +81,55 @@ class AlertsContent extends Component {
       'aria-controls': `tabpanel-${index}`,
     };
   }
+
+  async componentDidMount() {
+    let unresolvedAlerts = [];
+    let resolvedAlerts = [];
+
+    const alertsResponse = await fetch('/api/v1/alerts-data').then(response => response.json());
+    alertsResponse.forEach((alert) => {
+      // TODO: replace fakeid with actual alert ID (received from JSON, e.g. alert.id).
+      const fakeid = Math.floor(Math.random() * Math.floor(100));
+      this.state.allAlerts.set(fakeid, {
+        timestamp: createDate(alert.timestampDate), 
+        anomalies: alert.anomalies.length
+      });
+      if (alert.status === "UNRESOLVED") {
+        unresolvedAlerts.push(fakeid);
+      } else {
+        resolvedAlerts.push(fakeid);
+      }
+    });
+
+    this.setState({
+      unchecked: unresolvedAlerts.slice(),
+      checked: resolvedAlerts.slice(),
+    });
+  }
   
   handleTabs = (event, newTab) => {
     this.setState({tab: newTab});
   };
 
-  handleCheckbox = (value) => {
+  handleCheckbox = (alertId) => {
     const unchecked = this.state.unchecked.slice();
     const checked = this.state.checked.slice();
     const newUnchecked = [...unchecked];
     const newChecked = [...checked];
 
-    const currentUncheckedIndex = unchecked.indexOf(value);
-    const currentCheckedIndex = checked.indexOf(value);
+    const currentUncheckedIndex = unchecked.indexOf(alertId);
+    const currentCheckedIndex = checked.indexOf(alertId);
 
     if (currentCheckedIndex === -1 && currentUncheckedIndex !== -1) {
       // Was unresolved and now want to resolve it, second check is a sanity check.
-      newChecked.push(value);
+      newChecked.push(alertId);
       newUnchecked.splice(currentUncheckedIndex, 1);
     } else if (currentUncheckedIndex === -1 && currentCheckedIndex !== -1) {
       // Was resolved and now want to unresolve it, second check is a sanity check.
-      newUnchecked.push(value);
+      newUnchecked.push(alertId);
       newChecked.splice(currentCheckedIndex, 1);
     } else {
-      throw new Error("Misplaced alert: " + allAlerts[value]);
+      throw new Error("Misplaced alert: " + this.state.allAlerts[alertId]);
     }
 
     this.setState({
@@ -109,11 +137,11 @@ class AlertsContent extends Component {
       checked: newChecked,
     });
 
-    // TODO: send POST request to servlet with status change of alert at index = value.
+    // TODO: send POST request to servlet with status change of alert with alertId.
   };
 
   render() {
-    const { tab, unchecked, checked } = this.state;
+    const { tab, allAlerts, unchecked, checked } = this.state;
     const { classes } = this.props;
     return (
       <div className={classes.root}>
@@ -133,24 +161,24 @@ class AlertsContent extends Component {
         </Paper>
         <TabPanel value={tab} index={tabLabels.UNRESOLVED}>
           <AlertsList 
-            allAlerts = {allAlerts}
-            alerts={unchecked} 
+            allAlerts={allAlerts}
+            displayAlerts={unchecked} 
             checked={checked}
             handleToggle={this.handleCheckbox} 
           />
         </TabPanel>
         <TabPanel value={tab} index={tabLabels.RESOLVED}>
           <AlertsList 
-            allAlerts = {allAlerts}
-            alerts={checked} 
+            allAlerts={allAlerts}
+            displayAlerts={checked} 
             checked={checked}
             handleToggle={this.handleCheckbox} 
           />
         </TabPanel>
         <TabPanel value={tab} index={tabLabels.ALL}>
           <AlertsList 
-            allAlerts = {allAlerts}
-            alerts={unchecked.concat(checked)} 
+            allAlerts={allAlerts}
+            displayAlerts={unchecked.concat(checked)} 
             checked={checked}
             handleToggle={this.handleCheckbox}
           />

--- a/frontend/src/AlertsManagement/AlertsContent.test.js
+++ b/frontend/src/AlertsManagement/AlertsContent.test.js
@@ -107,7 +107,7 @@ describe("handleCheckbox", () => {
 });
 
 describe("fetch alerts", () => {
-  // Fake alert JSON data:
+  // Fake alert JSON data. TODO: add ID property in the future.
   const fakeAlerts = [{
     anomalies: [
       { dataPoints: {"2019-11-24": {value: 79}, }, 

--- a/frontend/src/AlertsManagement/AlertsContent.test.js
+++ b/frontend/src/AlertsManagement/AlertsContent.test.js
@@ -53,8 +53,8 @@ describe("handleCheckbox", () => {
     timestamp: "2019-08-06",
     anomalies: 2,
   });
-  const fakeUnresolved = [0, 1];
-  const fakeResolved = [2];
+  const fakeUnresolvedIds = [0, 1];
+  const fakeResolvedIds = [2];
 
   // Expected mock data.
   const editUnchecked = [1];
@@ -67,8 +67,8 @@ describe("handleCheckbox", () => {
     wrapper = shallow(<AlertsContent classes={styles} />, { disableLifecycleMethods: true });
     wrapper.setState({ 
       allAlerts: fakeAlerts,
-      unchecked: fakeUnresolved,
-      checked: fakeResolved,
+      unchecked: fakeUnresolvedIds,
+      checked: fakeResolvedIds,
     });
   });
 

--- a/frontend/src/AlertsManagement/AlertsContent.test.js
+++ b/frontend/src/AlertsManagement/AlertsContent.test.js
@@ -7,7 +7,7 @@ import { createShallow } from '@material-ui/core/test-utils';
 import { PureAlertsContent as AlertsContent } from "./AlertsContent";
 import AlertsList from "./AlertsList";
 
-configure({ adapter: new Adapter() });
+configure({ adapter: new Adapter(), disableLifecycleMethods: true });
 
 describe("handleTabs", () => {
   const tabLabels = {
@@ -39,10 +39,27 @@ describe("handleTabs", () => {
 });
 
 describe("handleCheckbox", () => {
-  const editUnchecked = [1, 2, 3];
-  const editChecked = [4, 5, 6, 0];
-  const missingChecked = [4, 5, 6];
-  const doubleChecked = [0, 4, 5, 6];
+  // Mock data for the alerts, unresolved and resolved.
+  const fakeAlerts = new Map();
+  fakeAlerts.set(0, {
+    timestamp: "2020-01-20",
+    anomalies: 3,
+  });
+  fakeAlerts.set(1, {
+    timestamp: "2019-09-19",
+    anomalies: 2,
+  });
+  fakeAlerts.set(2, {
+    timestamp: "2019-08-06",
+    anomalies: 2,
+  });
+  const fakeUnresolved = [0, 1];
+  const fakeResolved = [2];
+
+  // Expected mock data.
+  const editUnchecked = [1];
+  const editChecked = [2, 0];
+  const doubleChecked = [0, 2];
 
   const styles = { 
     root: {
@@ -52,9 +69,22 @@ describe("handleCheckbox", () => {
     }
   };
 
-  it("should maintain the correct unresolved and resolved elements after click", () => {
-    const wrapper = shallow(<AlertsContent classes={styles} />);
+  let wrapper;
 
+  beforeEach(() => {
+    wrapper = shallow(<AlertsContent classes={styles} />);
+    wrapper.setState({ 
+      allAlerts: fakeAlerts,
+      unchecked: fakeUnresolved,
+      checked: fakeResolved,
+    });
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  })
+
+  it("should maintain the correct unresolved and resolved elements after click", () => {
     act(() => {
       const boxes = wrapper.find(AlertsList).at(0).dive().find('WithStyles(ForwardRef(Checkbox))');
       boxes.at(0).simulate('click');
@@ -65,25 +95,25 @@ describe("handleCheckbox", () => {
   });
 
   it("should throw error if alert is considered both unresolved and resolved", () => {
-   const wrapper = shallow(<AlertsContent classes={styles} />);
     wrapper.setState({ checked: doubleChecked });
-    const boxes = wrapper.find(AlertsList).at(0).dive().find('WithStyles(ForwardRef(Checkbox))');
 
+    const boxes = wrapper.find(AlertsList).at(0).dive().find('WithStyles(ForwardRef(Checkbox))');
     function testCheckbox() { boxes.at(0).simulate('click'); }
 
-    expect(testCheckbox).toThrowError('Misplaced alert')
+    expect(testCheckbox).toThrowError('Misplaced alert');
   });
 
   it("should throw error if alert is neither unresolved nor resolved", () => {
-    const wrapper = shallow(<AlertsContent classes={styles} />);
-    wrapper.setState({ checked: missingChecked });
     const boxes = wrapper.find(AlertsList).at(0).dive().find('WithStyles(ForwardRef(Checkbox))');
     wrapper.setState({ unchecked: editUnchecked });
-
     function testCheckbox() { boxes.at(0).simulate('click'); }
 
     expect(testCheckbox).toThrowError('Misplaced alert')
   });
 
   // TODO: write test for sending POST request to servlet
+});
+
+describe("fetch alerts", () => {
+  
 });

--- a/frontend/src/AlertsManagement/AlertsContent.test.js
+++ b/frontend/src/AlertsManagement/AlertsContent.test.js
@@ -114,6 +114,7 @@ describe("handleCheckbox", () => {
   // TODO: write test for sending POST request to servlet
 });
 
+// TODO: write tests for fetching alerts (in componentDidMount).
 describe("fetch alerts", () => {
-  
+
 });

--- a/frontend/src/AlertsManagement/AlertsList.js
+++ b/frontend/src/AlertsManagement/AlertsList.js
@@ -8,13 +8,13 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 class AlertsList extends Component {
   render() {
-    const alerts = this.props.alerts;
-
+    const displayAlerts = this.props.displayAlerts;
+    const allAlerts = this.props.allAlerts;
+    
     return (
       <List className="alerts-list">
-        {/* alert represents the index of the actual alert in allAlerts array. */}
-        {alerts.map((alertIndex, value) => {
-          const labelId = `checkbox-list-label-${alertIndex}`;
+        {displayAlerts.map((alertId, value) => {
+          const labelId = `checkbox-list-label-${alertId}`;
 
           return (
             <ListItem key={value} role={undefined} dense divider>
@@ -22,14 +22,16 @@ class AlertsList extends Component {
                 <Tooltip title="Resolved?" placement="left">
                   <Checkbox
                     edge="start"
-                    checked={this.props.checked.indexOf(alertIndex) !== -1}
+                    checked={this.props.checked.indexOf(alertId) !== -1}
                     tabIndex={-1}
-                    onClick={() => this.props.handleToggle(alertIndex)}
+                    onClick={() => this.props.handleToggle(alertId)}
                     inputProps={{ 'aria-labelledby': labelId }}
                   />
                 </Tooltip>
               </ListItemIcon>
-              <ListItemText id={labelId} primary={`Alert number ${this.props.allAlerts[alertIndex] + 1}`} />
+              <ListItemText id={labelId} 
+                primary={`Alert ${alertId} on ${allAlerts.get(alertId).timestamp} has ${allAlerts.get(alertId).anomalies} anomalies`} 
+              />
             </ListItem>
           );
         })}

--- a/frontend/src/AlertsManagement/management_constants.js
+++ b/frontend/src/AlertsManagement/management_constants.js
@@ -1,0 +1,10 @@
+/*
+ * Constants for files in AlertManagement directory.
+ */
+
+export const tabLabels = {
+  UNRESOLVED: 0,
+  RESOLVED: 1,
+  ALL: 2,
+};
+export const UNRESOLVED_STATUS = "UNRESOLVED";

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import App from './App';
 import Dummy from './Dummy';
+import AlertsManagement from './AlertsManagement/AlertsManagement';
 import './index.css';
 
 ReactDOM.render(
@@ -12,10 +13,10 @@ ReactDOM.render(
         <Route exact path="/" component={App}>
         </Route>
         {/* Dummy is a temporary component to routing works */}
-        <Route path="/alerts" component={Dummy}>
+        <Route path="/alerts" component={AlertsManagement}>
           {/* TODO: import AlertsManagement */}
         </Route>
-        <Route path="/configs">
+        <Route path="/configs" component={Dummy}>
           {/* TODO: import AlertConfiguration */}
         </Route>
       </Switch>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -15,7 +15,7 @@ ReactDOM.render(
         <Route path="/alerts" component={Dummy}>
           {/* TODO: import AlertsManagement */}
         </Route>
-        <Route path="/configs" >
+        <Route path="/configs">
           {/* TODO: import AlertConfiguration */}
         </Route>
       </Switch>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import App from './App';
 import Dummy from './Dummy';
-import AlertsManagement from './AlertsManagement/AlertsManagement';
 import './index.css';
 
 ReactDOM.render(
@@ -13,10 +12,10 @@ ReactDOM.render(
         <Route exact path="/" component={App}>
         </Route>
         {/* Dummy is a temporary component to routing works */}
-        <Route path="/alerts" component={AlertsManagement}>
+        <Route path="/alerts" component={Dummy}>
           {/* TODO: import AlertsManagement */}
         </Route>
-        <Route path="/configs" component={Dummy}>
+        <Route path="/configs" >
           {/* TODO: import AlertConfiguration */}
         </Route>
       </Switch>

--- a/frontend/src/time_utils.js
+++ b/frontend/src/time_utils.js
@@ -1,8 +1,8 @@
 /*
- * Helper function to create Date from Timestamp model.
+ * Creates Date without a time from Timestamp model.
+ * Note: timestampDate.date.month is from 1-12, while JavaScript 'Date' is from 0-11.
  */
 export function convertTimestampToDate(timestampDate) {
-  // timestampDate.date.month is from 1-12, while JavaScript 'Date' is from 0-11.
   return new Date(
     timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
     .toDateString();

--- a/frontend/src/time_utils.js
+++ b/frontend/src/time_utils.js
@@ -1,0 +1,9 @@
+/*
+ * Helper function to create Date from Timestamp model.
+ */
+export function convertTimestampToDate(timestampDate) {
+  // timestampDate.date.month is from 1-12, while JavaScript 'Date' is from 0-11.
+  return new Date(
+    timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
+    .toDateString();
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1110,6 +1110,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.10.2", "@babel/runtime@^7.5.1":
   version "7.10.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.3.tgz#670d002655a7c366540c67f6fd3342cd09500364"
@@ -3084,7 +3091,7 @@ cheerio@^1.0.0-rc.3:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@^2.0.2, chokidar@^2.1.8:
+chokidar@^2.1.8:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
@@ -3558,6 +3565,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
+  dependencies:
+    node-fetch "2.6.0"
+
 cross-spawn@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.1.tgz#0ab56286e0f7c24e153d04cc2aa027e43a9a5d14"
@@ -3837,16 +3851,6 @@ csstype@^2.5.2, csstype@^2.6.5:
   version "2.6.13"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
-
-csstype@^2.2.0:
-  version "2.6.10"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.10.tgz#e63af50e66d7c266edb6b32909cfd0aabe03928b"
-  integrity sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==
-
-csstype@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.2.tgz#ee5ff8f208c8cd613b389f7b222c9801ca62b3f7"
-  integrity sha512-ofovWglpqoqbfLNOTBNZLSbMuGrblAf1efvvArGKOZMBrIoJeu5UsAipQolkijtyQx5MtAzT/J9IHj/CEY1mJw==
 
 csstype@^3.0.2:
   version "3.0.2"
@@ -4385,24 +4389,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
-  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
-  dependencies:
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.2.0"
-    is-regex "^1.1.0"
-    object-inspect "^1.7.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.0"
-    string.prototype.trimend "^1.0.1"
-    string.prototype.trimstart "^1.0.1"
-
-es-abstract@^1.17.4, es-abstract@^1.17.5:
+es-abstract@^1.17.0, es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.4, es-abstract@^1.17.5:
   version "1.17.6"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
   integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
@@ -6018,12 +6005,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
-
-is-callable@^1.2.0:
+is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
   integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
@@ -6210,14 +6192,7 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-regex@^1.0.4, is-regex@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
-  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
-  dependencies:
-    has-symbols "^1.0.1"
-
-is-regex@^1.1.0:
+is-regex@^1.0.4, is-regex@^1.0.5, is-regex@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -6480,6 +6455,14 @@ jest-environment-node@^24.9.0:
     "@jest/types" "^24.9.0"
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
+
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  dependencies:
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
 
 jest-get-type@^24.9.0:
   version "24.9.0"
@@ -7222,12 +7205,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.15.0:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -7689,6 +7667,11 @@ no-case@^3.0.3:
     lower-case "^2.0.1"
     tslib "^1.10.0"
 
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
@@ -7849,15 +7832,7 @@ object-inspect@^1.7.0:
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
-object-is@^1.0.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
-  integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-
-object-is@^1.0.2, object-is@^1.1.2:
+object-is@^1.0.1, object-is@^1.0.2, object-is@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.2.tgz#c5d2e87ff9e119f78b7a088441519e2eec1573b6"
   integrity sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==
@@ -7892,16 +7867,7 @@ object.assign@^4.1.0:
     has-symbols "^1.0.0"
     object-keys "^1.0.11"
 
-object.entries@^1.1.0, object.entries@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
-  integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    has "^1.0.3"
-
-object.entries@^1.1.2:
+object.entries@^1.1.0, object.entries@^1.1.1, object.entries@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.2.tgz#bc73f00acb6b6bb16c203434b10f9a7e797d3add"
   integrity sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==
@@ -9162,6 +9128,11 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
+
 promise@^8.0.3:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/promise/-/promise-8.1.0.tgz#697c25c3dfe7435dd79fcd58c38a135888eaf05e"
@@ -9430,7 +9401,7 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.13.1, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9526,17 +9497,23 @@ react-scripts@3.4.1:
 
 react-test-renderer@^16.0.0-0:
   version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
   integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
   dependencies:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+    react-is "^16.8.6"
     scheduler "^0.19.1"
 
 react-transition-group@^4.4.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"
   integrity sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react@^16.13.1:
   version "16.13.1"
@@ -10667,22 +10644,6 @@ string.prototype.trimend@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
   integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-
-string.prototype.trimleft@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz#9bdb8ac6abd6d602b17a4ed321870d2f8dcefc74"
-  integrity sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-
-string.prototype.trimstart@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
-  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.5"


### PR DESCRIPTION
The frontend for AlertsContent will fetch alerts from the Datastore, process the received JSON data, and set the state of the component in componentDidMount. This information is passed to the AlertsList child components to render the alert information. Tests for AlertsContent that were written in an earlier PR were modified to match the updated logic.

TODO (in this PR): add tests for AlertsDataServlet's doGet function

Here's what the UI looks like now with the fetched alerts. Note that these alerts are in the local Datastore of another branch, not this one. Also, note that the number after Alert (e.g. Alert 61, Alert 74) is a fake ID and not the real ID of the alert. (I originally made this a random number but decided it didn't make much sense, the screenshot is from when I had a random fake ID.) When Melody adds the code for the saving the ID as a property of the model, I will go back to this code, edit it so that the ID isn't actually displayed and write the POST request to change the status of the alert itself. I think that will be the full implementation of this feature.
![Screenshot 2020-08-12 at 6 08 21 PM - Display 2](https://user-images.githubusercontent.com/39574893/90073269-e6151c80-dcc6-11ea-83aa-fbfd14b4e3cb.png)