### PR TITLE
Add tests for alert and anomaly generators

### DIFF
--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Collections;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
-import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.LinkedListMultimap;
 
 /** Generate list of alerts by grouping anomalies by their month. */
 public class SimpleAlertGenerator implements AlertGenerator {
@@ -33,7 +33,7 @@ public class SimpleAlertGenerator implements AlertGenerator {
   /** TODO: Make flexible so can not only group anomalies by month but other time span. */
   private static ImmutableList<Alert> groupAnomaliesToAlerts(AnomalyGenerator anomalyGenerator) {
     List<Anomaly> anomaliesList = anomalyGenerator.getAnomalies();
-    ListMultimap<Timestamp, Anomaly> anomalyGroups = ArrayListMultimap.create();
+    ListMultimap<Timestamp, Anomaly> anomalyGroups = LinkedListMultimap.create();
 
     // Group anomalies by month.
     for (Anomaly currAnomaly : anomaliesList) {

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
@@ -59,7 +59,14 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
     // Find instances where exceed threshold.
     Map<Timestamp, Integer> anomalyPoints = data.entrySet().stream()
         .filter(entry -> entry.getValue() - avg > threshold)
-        .collect(toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+        .collect(toMap(
+            entry -> entry.getKey(), 
+            entry -> entry.getValue(),
+            // In case of conflicting keys, pick value of second key. 
+            // But there should not be conflicting keys at all. 
+            (x, y) -> y,
+            LinkedHashMap::new
+          ));
 
     // Create anomaly objects from those instances.
     return anomalyPoints.keySet().stream()

--- a/backend/src/test/java/com/google/blackswan/mock/MockTestHelper.java
+++ b/backend/src/test/java/com/google/blackswan/mock/MockTestHelper.java
@@ -1,0 +1,17 @@
+package com.google.blackswan.servlets;
+
+import java.util.Map;
+
+/** Contain helper methods for blackswan mock tests. */
+public final class MockTestHelper {
+
+  /** Outputs data based on input using format of csv data. */
+  public static String inputForAnomalyGenerator(Map<String, Integer> input) {
+    StringBuilder str = new StringBuilder("");
+    for (Map.Entry<String, Integer> entry : input.entrySet()) {
+      str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
+    }
+    return str.toString();
+  }
+
+}

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
@@ -10,12 +10,12 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
 import com.google.blackswan.mock.*;
 import com.google.models.*;
 import com.google.common.collect.ImmutableMap;
@@ -39,11 +39,13 @@ public class SimpleAlertGeneratorTest {
   private static final int SET_THRESHOLD_LOW = 2;
   private static final int SET_DATAPOINTS = 2;
   private static final int EXPECTED_ALERT_SIZE = 2;
-  private static final AlertGenerator alertGenerator = new SimpleAlertGenerator(
+  private static final AlertGenerator ALERT_GENERATOR = new SimpleAlertGenerator(
     SimpleAnomalyGenerator.createGeneratorWithString(
-      inputForAnomalyGenerator(), SET_THRESHOLD_LOW, SET_DATAPOINTS
+      MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
+      SET_THRESHOLD_LOW, SET_DATAPOINTS
     )
   );
+
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
 
@@ -99,19 +101,11 @@ public class SimpleAlertGeneratorTest {
       Alert.StatusType.UNRESOLVED
     );
 
-    List<Alert> generatedAlerts = alertGenerator.getAlerts();
+    List<Alert> generatedAlerts = ALERT_GENERATOR.getAlerts();
 
-    assertEquals(generatedAlerts.size(), EXPECTED_ALERT_SIZE);
-    assertEquals(generatedAlerts.get(0), expectedAlertJuly);
-    assertEquals(generatedAlerts.get(1), expectedAlertAugust);
-  }
-
-  private static String inputForAnomalyGenerator() {
-    StringBuilder str = new StringBuilder("");
-    for (Map.Entry<String, Integer> entry : SAMPLE_DATA.entrySet()) {
-      str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
-    }
-    return str.toString();
+    assertEquals(EXPECTED_ALERT_SIZE, generatedAlerts.size());
+    assertEquals(expectedAlertJuly, generatedAlerts.get(0));
+    assertEquals(expectedAlertAugust, generatedAlerts.get(1));
   }
 
 }

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
@@ -2,10 +2,6 @@ package com.google.blackswan.servlets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.atLeast;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
@@ -20,10 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
-
 import com.google.blackswan.mock.*;
 import com.google.models.*;
 import com.google.common.collect.ImmutableMap;
@@ -32,12 +24,12 @@ import java.util.Map;
 import java.util.List;
 import java.util.Arrays;
 
-/** Contain tests for methods in the {@link CronServlet} class. */
+/** Contain tests for methods in the {@link SimpleAlertGenerator} class. */
 @RunWith(JUnit4.class)
 public class SimpleAlertGeneratorTest {
   private static final String METRIC_NAME = "Interest Over Time";
   private static final String DIMENSION_NAME = "Ramen";
-  private static final Map<String, Integer> SAMPLE_DATA = ImmutableMap.of(
+  private static final ImmutableMap<String, Integer> SAMPLE_DATA = ImmutableMap.of(
     "2019-07-21", 73, 
     "2019-07-28", 59, 
     "2019-08-04", 75,
@@ -68,7 +60,7 @@ public class SimpleAlertGeneratorTest {
   @Test
   public void getAlerts_returnsListOfAlerts() {
     // Create first expected alert which contains one anomaly in July.
-    Map<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
       new Timestamp("2019-07-21"), new MetricValue(73),
       new Timestamp("2019-07-28"), new MetricValue(59), 
       new Timestamp("2019-08-04"), new MetricValue(75)
@@ -82,7 +74,7 @@ public class SimpleAlertGeneratorTest {
       Alert.StatusType.UNRESOLVED
     );
     // Create second expected alert which contains two anomalies that occurs in August. 
-    Map<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
       new Timestamp("2019-07-21"), new MetricValue(73),
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 
@@ -92,7 +84,7 @@ public class SimpleAlertGeneratorTest {
     Anomaly expectedAnomalyGroup2_1 = new Anomaly(
       new Timestamp("2019-08-04"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints2
     );
-    Map<Timestamp, MetricValue> expectedDataPoints3 = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints3 = ImmutableMap.of(
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 
       new Timestamp("2019-08-11"), new MetricValue(79), 

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
@@ -1,0 +1,125 @@
+package com.google.blackswan.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.google.blackswan.mock.*;
+import com.google.models.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import java.util.Map;
+import java.util.List;
+import java.util.Arrays;
+
+/** Contain tests for methods in the {@link CronServlet} class. */
+@RunWith(JUnit4.class)
+public class SimpleAlertGeneratorTest {
+  private static final String METRIC_NAME = "Interest Over Time";
+  private static final String DIMENSION_NAME = "Ramen";
+  private static final Map<String, Integer> SAMPLE_DATA = ImmutableMap.of(
+    "2019-07-21", 73, 
+    "2019-07-28", 59, 
+    "2019-08-04", 75,
+    "2019-08-11", 79,
+    "2019-08-18", 67
+  );
+  private static final int SET_THRESHOLD_LOW = 2;
+  private static final int SET_DATAPOINTS = 2;
+  private static final int EXPECTED_ALERT_SIZE = 2;
+  private static final AlertGenerator alertGenerator = new SimpleAlertGenerator(
+    SimpleAnomalyGenerator.createGeneratorWithString(
+      inputForAnomalyGenerator(), SET_THRESHOLD_LOW, SET_DATAPOINTS
+    )
+  );
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void getAlerts_returnsListOfAlerts() {
+    // Create first expected alert which contains one anomaly in July.
+    Map<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
+      new Timestamp("2019-07-21"), new MetricValue(73),
+      new Timestamp("2019-07-28"), new MetricValue(59), 
+      new Timestamp("2019-08-04"), new MetricValue(75)
+    );
+    Anomaly expectedAnomalyGroup1 = new Anomaly(
+      new Timestamp("2019-07-21"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints1
+    );
+    Alert expectedAlertJuly = new Alert(
+      new Timestamp("2019-08-01"), 
+      Arrays.asList(expectedAnomalyGroup1), 
+      Alert.StatusType.UNRESOLVED
+    );
+    // Create second expected alert which contains two anomalies that occurs in August. 
+    Map<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
+      new Timestamp("2019-07-21"), new MetricValue(73),
+      new Timestamp("2019-07-28"), new MetricValue(59),
+      new Timestamp("2019-08-04"), new MetricValue(75), 
+      new Timestamp("2019-08-11"), new MetricValue(79), 
+      new Timestamp("2019-08-18"), new MetricValue(67)
+    );
+    Anomaly expectedAnomalyGroup2_1 = new Anomaly(
+      new Timestamp("2019-08-04"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints2
+    );
+    Map<Timestamp, MetricValue> expectedDataPoints3 = ImmutableMap.of(
+      new Timestamp("2019-07-28"), new MetricValue(59),
+      new Timestamp("2019-08-04"), new MetricValue(75), 
+      new Timestamp("2019-08-11"), new MetricValue(79), 
+      new Timestamp("2019-08-18"), new MetricValue(67)
+    );
+    Anomaly expectedAnomalyGroup2_2 = new Anomaly(
+      new Timestamp("2019-08-11"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints3
+    );
+    Alert expectedAlertAugust = new Alert(
+      new Timestamp("2019-09-01"), 
+      Arrays.asList(expectedAnomalyGroup2_1, expectedAnomalyGroup2_2), 
+      Alert.StatusType.UNRESOLVED
+    );
+
+    List<Alert> generatedAlerts = alertGenerator.getAlerts();
+
+    assertEquals(generatedAlerts.size(), EXPECTED_ALERT_SIZE);
+    assertEquals(generatedAlerts.get(0), expectedAlertJuly);
+    assertEquals(generatedAlerts.get(1), expectedAlertAugust);
+  }
+
+  private static String inputForAnomalyGenerator() {
+    StringBuilder str = new StringBuilder("");
+    for (Map.Entry<String, Integer> entry : SAMPLE_DATA.entrySet()) {
+      str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
+    }
+    return str.toString();
+  }
+
+}

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
@@ -10,7 +10,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,8 +38,10 @@ public class SimpleAnomalyGeneratorTest {
   private static final int SET_THRESHOLD_HIGH = 6;
   private static final int SET_THRESHOLD_LOW = 4;
   private static final int SET_DATAPOINTS = 2;
+
   private final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  
   private SimpleAnomalyGenerator anomalyGenerator; 
       
 
@@ -57,7 +58,8 @@ public class SimpleAnomalyGeneratorTest {
   @Test
   public void getAnomalies_returnsListOfAnomaliesWithSizeOne() {
     anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
-      inputForAnomalyGenerator(), SET_THRESHOLD_HIGH, SET_DATAPOINTS
+      MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
+      SET_THRESHOLD_HIGH, SET_DATAPOINTS
     );
     // Avg = 70, only 1 data point exceeds 76. 
     ImmutableMap<Timestamp, MetricValue> expectedDataPoints = ImmutableMap.of(
@@ -72,14 +74,15 @@ public class SimpleAnomalyGeneratorTest {
 
     List<Anomaly> generatedAnomalies = anomalyGenerator.getAnomalies();
 
-    assertEquals(generatedAnomalies.size(), 1);
-    assertEquals(generatedAnomalies.get(0), expectedAnomaly);
+    assertEquals(1, generatedAnomalies.size());
+    assertEquals(expectedAnomaly, generatedAnomalies.get(0));
   }
 
   @Test
   public void getAnomalies_returnsListOfAnomaliesWithSizeTwo() {
     anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
-      inputForAnomalyGenerator(), SET_THRESHOLD_LOW, SET_DATAPOINTS
+      MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
+      SET_THRESHOLD_LOW, SET_DATAPOINTS
     );
     // Avg = 70, only 2 data points exceed 74.
     ImmutableMap<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
@@ -104,17 +107,9 @@ public class SimpleAnomalyGeneratorTest {
 
     List<Anomaly> generatedAnomalies = anomalyGenerator.getAnomalies();
 
-    assertEquals(generatedAnomalies.size(), 2);
-    assertEquals(generatedAnomalies.get(0), expectedAnomaly1);
-    assertEquals(generatedAnomalies.get(1), expectedAnomaly2);
-  }
-
-  private static String inputForAnomalyGenerator() {
-    StringBuilder str = new StringBuilder("");
-    for (Map.Entry<String, Integer> entry : SAMPLE_DATA.entrySet()) {
-      str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
-    }
-    return str.toString();
+    assertEquals(2, generatedAnomalies.size());
+    assertEquals(expectedAnomaly1, generatedAnomalies.get(0));
+    assertEquals(expectedAnomaly2, generatedAnomalies.get(1));
   }
 
 }

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
@@ -2,10 +2,6 @@ package com.google.blackswan.servlets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.atLeast;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
@@ -20,9 +16,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 import com.google.blackswan.mock.*;
 import com.google.models.*;
@@ -31,12 +24,12 @@ import com.google.common.collect.ImmutableList;
 import java.util.Map;
 import java.util.List;
 
-/** Contain tests for methods in the {@link CronServlet} class. */
+/** Contain tests for methods in the {@link SimpleAnomalyGenerator} class. */
 @RunWith(JUnit4.class)
 public class SimpleAnomalyGeneratorTest {
   private static final String METRIC_NAME = "Interest Over Time";
   private static final String DIMENSION_NAME = "Ramen";
-  private static final Map<String, Integer> SAMPLE_DATA = ImmutableMap.of(
+  private static final ImmutableMap<String, Integer> SAMPLE_DATA = ImmutableMap.of(
     "2019-07-21", 73, 
     "2019-07-28", 59, 
     "2019-08-04", 75,
@@ -67,7 +60,7 @@ public class SimpleAnomalyGeneratorTest {
       inputForAnomalyGenerator(), SET_THRESHOLD_HIGH, SET_DATAPOINTS
     );
     // Avg = 70, only 1 data point exceed 76. 
-    Map<Timestamp, MetricValue> expectedDataPoints = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints = ImmutableMap.of(
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 
       new Timestamp("2019-08-11"), new MetricValue(79), 
@@ -89,7 +82,7 @@ public class SimpleAnomalyGeneratorTest {
       inputForAnomalyGenerator(), SET_THRESHOLD_LOW, SET_DATAPOINTS
     );
     // Avg = 70, only 2 data points exceed 74.
-    Map<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
       new Timestamp("2019-07-21"), new MetricValue(73),
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 
@@ -99,7 +92,7 @@ public class SimpleAnomalyGeneratorTest {
     Anomaly expectedAnomaly1 = new Anomaly(
       new Timestamp("2019-08-04"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints1
     );
-    Map<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
+    ImmutableMap<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 
       new Timestamp("2019-08-11"), new MetricValue(79), 
@@ -116,7 +109,7 @@ public class SimpleAnomalyGeneratorTest {
     assertEquals(generatedAnomalies.get(1), expectedAnomaly2);
   }
 
-  private String inputForAnomalyGenerator() {
+  private static String inputForAnomalyGenerator() {
     StringBuilder str = new StringBuilder("");
     for (Map.Entry<String, Integer> entry : SAMPLE_DATA.entrySet()) {
       str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
@@ -59,7 +59,7 @@ public class SimpleAnomalyGeneratorTest {
     anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
       inputForAnomalyGenerator(), SET_THRESHOLD_HIGH, SET_DATAPOINTS
     );
-    // Avg = 70, only 1 data point exceed 76. 
+    // Avg = 70, only 1 data point exceeds 76. 
     ImmutableMap<Timestamp, MetricValue> expectedDataPoints = ImmutableMap.of(
       new Timestamp("2019-07-28"), new MetricValue(59),
       new Timestamp("2019-08-04"), new MetricValue(75), 

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
@@ -1,0 +1,127 @@
+package com.google.blackswan.servlets;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.atLeast;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.google.blackswan.mock.*;
+import com.google.models.*;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
+import java.util.Map;
+import java.util.List;
+
+/** Contain tests for methods in the {@link CronServlet} class. */
+@RunWith(JUnit4.class)
+public class SimpleAnomalyGeneratorTest {
+  private static final String METRIC_NAME = "Interest Over Time";
+  private static final String DIMENSION_NAME = "Ramen";
+  private static final Map<String, Integer> SAMPLE_DATA = ImmutableMap.of(
+    "2019-07-21", 73, 
+    "2019-07-28", 59, 
+    "2019-08-04", 75,
+    "2019-08-11", 79,
+    "2019-08-18", 67
+  );
+  private static final int SET_THRESHOLD_HIGH = 6;
+  private static final int SET_THRESHOLD_LOW = 4;
+  private static final int SET_DATAPOINTS = 2;
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  private SimpleAnomalyGenerator anomalyGenerator; 
+      
+
+  @Before
+  public void setUp() throws Exception {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void getAnomalies_returnsListOfAnomaliesWithSizeOne() {
+    anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
+      inputForAnomalyGenerator(), SET_THRESHOLD_HIGH, SET_DATAPOINTS
+    );
+    // Avg = 70, only 1 data point exceed 76. 
+    Map<Timestamp, MetricValue> expectedDataPoints = ImmutableMap.of(
+      new Timestamp("2019-07-28"), new MetricValue(59),
+      new Timestamp("2019-08-04"), new MetricValue(75), 
+      new Timestamp("2019-08-11"), new MetricValue(79), 
+      new Timestamp("2019-08-18"), new MetricValue(67)
+    );
+    Anomaly expectedAnomaly = new Anomaly(
+      new Timestamp("2019-08-11"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints
+    );
+
+    List<Anomaly> generatedAnomalies = anomalyGenerator.getAnomalies();
+
+    assertEquals(generatedAnomalies.size(), 1);
+    assertEquals(generatedAnomalies.get(0), expectedAnomaly);
+  }
+
+  @Test
+  public void getAnomalies_returnsListOfAnomaliesWithSizeTwo() {
+    anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
+      inputForAnomalyGenerator(), SET_THRESHOLD_LOW, SET_DATAPOINTS
+    );
+    // Avg = 70, only 2 data points exceed 74.
+    Map<Timestamp, MetricValue> expectedDataPoints1 = ImmutableMap.of(
+      new Timestamp("2019-07-21"), new MetricValue(73),
+      new Timestamp("2019-07-28"), new MetricValue(59),
+      new Timestamp("2019-08-04"), new MetricValue(75), 
+      new Timestamp("2019-08-11"), new MetricValue(79), 
+      new Timestamp("2019-08-18"), new MetricValue(67)
+    );
+    Anomaly expectedAnomaly1 = new Anomaly(
+      new Timestamp("2019-08-04"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints1
+    );
+    Map<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
+      new Timestamp("2019-07-28"), new MetricValue(59),
+      new Timestamp("2019-08-04"), new MetricValue(75), 
+      new Timestamp("2019-08-11"), new MetricValue(79), 
+      new Timestamp("2019-08-18"), new MetricValue(67)
+    );
+    Anomaly expectedAnomaly2 = new Anomaly(
+      new Timestamp("2019-08-11"), METRIC_NAME, DIMENSION_NAME, expectedDataPoints2
+    );
+
+    List<Anomaly> generatedAnomalies = anomalyGenerator.getAnomalies();
+
+    assertEquals(generatedAnomalies.size(), 2);
+    assertEquals(generatedAnomalies.get(0), expectedAnomaly1);
+    assertEquals(generatedAnomalies.get(1), expectedAnomaly2);
+  }
+
+  private String inputForAnomalyGenerator() {
+    StringBuilder str = new StringBuilder("");
+    for (Map.Entry<String, Integer> entry : SAMPLE_DATA.entrySet()) {
+      str.append(entry.getKey() + "," + entry.getValue().toString() + "\n");
+    }
+    return str.toString();
+  }
+
+}

--- a/backend/src/test/java/com/google/models/AnomalyTest.java
+++ b/backend/src/test/java/com/google/models/AnomalyTest.java
@@ -32,8 +32,10 @@ public final class AnomalyTest {
       Timestamp.getDummyTimestamp(3), new MetricValue(3));
   private static final LocalServiceTestHelper helper =
       new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
-  private static final Anomaly ANOMALY = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
-      METRIC_NAME, DIMENSION_NAME, DATA_POINTS);
+  private static final Anomaly ANOMALY = new Anomaly(
+      Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+      METRIC_NAME, DIMENSION_NAME, DATA_POINTS
+    );
 
   @Before
   public void setUp() throws Exception {
@@ -47,28 +49,29 @@ public final class AnomalyTest {
 
   @Test
   public void getTimestamp_workingGetter() {
-    assertEquals(ANOMALY.getTimestamp(), Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT));
+    assertEquals(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+        ANOMALY.getTimestamp());
   }
 
   @Test
   public void getMetricName_workingGetter() {
-    assertEquals(ANOMALY.getMetricName(), METRIC_NAME);
+    assertEquals(METRIC_NAME, ANOMALY.getMetricName());
   }
 
   @Test
   public void getDimensionName_workingGetter() {
-    assertEquals(ANOMALY.getDimensionName(), DIMENSION_NAME);
+    assertEquals(DIMENSION_NAME, ANOMALY.getDimensionName());
   }
 
   @Test
   public void getDataPoints_workingGetter() {
-    assertEquals(ANOMALY.getDataPoints(), DATA_POINTS);
+    assertEquals(DATA_POINTS, ANOMALY.getDataPoints());
   }
 
   @Test
   public void equals_workingComparator() {
-    Anomaly sameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), METRIC_NAME, 
-        DIMENSION_NAME, DATA_POINTS);
+    Anomaly sameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT),  
+        METRIC_NAME, DIMENSION_NAME, DATA_POINTS);
     Anomaly diffTimeAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT + 1), 
         METRIC_NAME, DIMENSION_NAME, DATA_POINTS);
     Anomaly diffMetricNameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
@@ -76,9 +79,11 @@ public final class AnomalyTest {
     Anomaly diffDimensionNameAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
         METRIC_NAME, "diff name", DATA_POINTS);
     Anomaly diffDataPointsAnomaly = new Anomaly(Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
-        METRIC_NAME, "diff name", ImmutableMap.of(Timestamp.getDummyTimestamp(2), new MetricValue(5), 
-                                                  Timestamp.getDummyTimestamp(1), new MetricValue(2), 
-                                                  Timestamp.getDummyTimestamp(3), new MetricValue(3)));
+      METRIC_NAME, "diff name", 
+      ImmutableMap.of(Timestamp.getDummyTimestamp(2), new MetricValue(5), 
+                      Timestamp.getDummyTimestamp(1), new MetricValue(2), 
+                      Timestamp.getDummyTimestamp(3), new MetricValue(3))
+    );
 
     assertTrue(ANOMALY.equals(ANOMALY));
     assertTrue(ANOMALY.equals(sameAnomaly));
@@ -100,44 +105,54 @@ public final class AnomalyTest {
       expectedStr.append(key + ": " + value + "\n")
     );
 
-    assertEquals(ANOMALY.toString(), expectedStr.toString());
+    assertEquals(expectedStr.toString(), ANOMALY.toString());
   }
 
   @Test
   public void toEntity_correctAnomalyToEntityConversion() {
     Entity anomalyEntity = ANOMALY.toEntity();
-    EmbeddedEntity dataPointsEE = (EmbeddedEntity) anomalyEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
+    EmbeddedEntity dataPointsEE = 
+        (EmbeddedEntity) anomalyEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
     
     assertFalse(dataPointsEE.equals(null));
-    assertTrue(embeddedEntityDataPoints_equal(dataPointsEE, ANOMALY.getDataPoints()));
-    assertEquals(anomalyEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), ANOMALY.getTimestamp().toString());
-    assertEquals(anomalyEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY), ANOMALY.getMetricName());
-    assertEquals(anomalyEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY), ANOMALY.getDimensionName());
+    assertTrue(embeddedEntityDataPoints_equal(ANOMALY.getDataPoints(), 
+        dataPointsEE));
+    assertEquals(ANOMALY.getTimestamp().toString(), 
+        anomalyEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY));
+    assertEquals(ANOMALY.getMetricName(), 
+        anomalyEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY));
+    assertEquals(ANOMALY.getDimensionName(), 
+        anomalyEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY));
   }
 
   @Test
   public void toEmbeddedEntity_correctAnomalyToEmbeddedEntityConversion() {
     EmbeddedEntity anomalyEmbeddedEntity = ANOMALY.toEmbeddedEntity();
-    EmbeddedEntity dataPointsEE = (EmbeddedEntity) anomalyEmbeddedEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
+    EmbeddedEntity dataPointsEE = 
+        (EmbeddedEntity) anomalyEmbeddedEntity.getProperty(Anomaly.DATA_POINTS_PROPERTY);
     
     assertNotNull(dataPointsEE);
-    assertTrue(embeddedEntityDataPoints_equal(dataPointsEE, ANOMALY.getDataPoints()));
-    assertEquals(anomalyEmbeddedEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), ANOMALY.getTimestamp().toString());
-    assertEquals(anomalyEmbeddedEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY), ANOMALY.getMetricName());
-    assertEquals(anomalyEmbeddedEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY), ANOMALY.getDimensionName());
+    assertTrue(embeddedEntityDataPoints_equal(ANOMALY.getDataPoints(), dataPointsEE));
+    assertEquals(ANOMALY.getTimestamp().toString(), 
+        anomalyEmbeddedEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY));
+    assertEquals(ANOMALY.getMetricName(), 
+        anomalyEmbeddedEntity.getProperty(Anomaly.METRIC_NAME_PROPERTY));
+    assertEquals(ANOMALY.getDimensionName(), 
+        anomalyEmbeddedEntity.getProperty(Anomaly.DIMENSION_NAME_PROPERTY));
   }
 
   @Test
   public void createAnomalyFromEmbeddedEntity_correctEmbeddedEntityToAnomalyConversion() {
     EmbeddedEntity anomalyEmbeddedEntity = ANOMALY.toEmbeddedEntity();
-    Anomaly convertedAnomaly = Anomaly.createAnomalyFromEmbeddedEntity(anomalyEmbeddedEntity);
+    Anomaly convertedAnomaly = 
+        Anomaly.createAnomalyFromEmbeddedEntity(anomalyEmbeddedEntity);
 
-    assertEquals(convertedAnomaly, ANOMALY);
+    assertEquals(ANOMALY, convertedAnomaly);
   }
 
 
-  private boolean embeddedEntityDataPoints_equal(EmbeddedEntity dataPointsEE, 
-      Map<Timestamp, MetricValue> dataPointsMap) {
+  private boolean embeddedEntityDataPoints_equal(Map<Timestamp, MetricValue> dataPointsMap,
+      EmbeddedEntity dataPointsEE) {
     return dataPointsMap.entrySet().stream().allMatch(
       e -> e.getValue().getValue() == ((long) dataPointsEE.getProperty(e.getKey().toString()))
     );

--- a/backend/src/test/java/com/google/models/MetricValueTest.java
+++ b/backend/src/test/java/com/google/models/MetricValueTest.java
@@ -16,11 +16,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class MetricValueTest {
   private static final int VALUE_CONST = 1;
-  private static final MetricValue metricValue = new MetricValue(VALUE_CONST);
+  private static final MetricValue METRIC_VALUE = new MetricValue(VALUE_CONST);
 
   @Test
   public void getValue_workingGetter() {
-    assertEquals(metricValue.getValue(), VALUE_CONST);
+    assertEquals(VALUE_CONST, METRIC_VALUE.getValue());
   }
 
   @Test
@@ -28,10 +28,10 @@ public final class MetricValueTest {
     MetricValue sameMetricValue = new MetricValue(VALUE_CONST);
     MetricValue diffMetricValue = new MetricValue(VALUE_CONST + 1);
 
-    assertEquals(metricValue, metricValue);
-    assertEquals(sameMetricValue, metricValue);
-    assertFalse(metricValue.equals(diffMetricValue));
-    assertFalse(metricValue.equals(null));
+    assertEquals(METRIC_VALUE, METRIC_VALUE);
+    assertEquals(METRIC_VALUE, sameMetricValue);
+    assertFalse(METRIC_VALUE.equals(diffMetricValue));
+    assertFalse(METRIC_VALUE.equals(null));
   }
 
   /** TODO: Add tests for toString() and other methods once logic of Metric Value complicates. */

--- a/backend/src/test/java/com/google/models/TimestampTest.java
+++ b/backend/src/test/java/com/google/models/TimestampTest.java
@@ -19,7 +19,7 @@ public final class TimestampTest {
   private static final int DAY_CONST = 1;
   private static final int MONTH_CONST = 1;
   private static final int YEAR_CONST = 2000;
-  private static final Timestamp timestamp = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
+  private static final Timestamp TIMESTAMP = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
 
   @Test
   public void constructor_convertStringToDate() {
@@ -27,15 +27,15 @@ public final class TimestampTest {
     Timestamp stringTimestampPaddedZero = new Timestamp("2020-12-05");
     Timestamp stringTimestampDiff = new Timestamp("2020-1-01");
 
-    assertEquals(stringTimestamp.getDay(), 5);
-    assertEquals(stringTimestamp.getMonth(), 12);
-    assertEquals(stringTimestamp.getYear(), 2020);
-    assertEquals(stringTimestampPaddedZero.getDay(), 5);
-    assertEquals(stringTimestampPaddedZero.getMonth(), 12);
-    assertEquals(stringTimestampPaddedZero.getYear(), 2020);
-    assertEquals(stringTimestampDiff.getDay(), 1);
-    assertEquals(stringTimestampDiff.getMonth(), 1);
-    assertEquals(stringTimestampDiff.getYear(), 2020);
+    assertEquals(5, stringTimestamp.getDay());
+    assertEquals(12, stringTimestamp.getMonth());
+    assertEquals(2020, stringTimestamp.getYear());
+    assertEquals(5, stringTimestampPaddedZero.getDay());
+    assertEquals(12, stringTimestampPaddedZero.getMonth());
+    assertEquals(2020, stringTimestampPaddedZero.getYear());
+    assertEquals(1, stringTimestampDiff.getDay());
+    assertEquals(1, stringTimestampDiff.getMonth());
+    assertEquals(2020, stringTimestampDiff.getYear());
   }
 
   @Test(expected = DateTimeParseException.class)
@@ -55,8 +55,11 @@ public final class TimestampTest {
 
   @Test
   public void toString_correctConversion() {
-    assertEquals(timestamp.toString(),
-        YEAR_CONST + "-" + String.format("%02d", MONTH_CONST) + "-" + String.format("%02d", DAY_CONST));
+    assertEquals(
+      YEAR_CONST + "-" + String.format("%02d", MONTH_CONST) + "-" + 
+          String.format("%02d", DAY_CONST),
+      TIMESTAMP.toString()
+    );
   }
 
   @Test
@@ -64,10 +67,10 @@ public final class TimestampTest {
     Timestamp sameTimestamp = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
     Timestamp diffTimestamp = new Timestamp(DAY_CONST + 1, MONTH_CONST, YEAR_CONST);
 
-    assertEquals(timestamp, timestamp);
-    assertEquals(sameTimestamp, timestamp);
-    assertFalse(timestamp.equals(diffTimestamp));
-    assertFalse(timestamp.equals(null));
+    assertEquals(TIMESTAMP, TIMESTAMP);
+    assertEquals(TIMESTAMP, sameTimestamp);
+    assertFalse(TIMESTAMP.equals(diffTimestamp));
+    assertFalse(TIMESTAMP.equals(null));
   }
 
 }


### PR DESCRIPTION
Add tests for `SimpleAlertGenerator` and `SimpleAnomalyGenerator` that is in pull request (#19).

Tests added for all `public` methods besides constructors and `static` create methods which are not needed for now (after discussion with Paula). 

The expected anomaly/alert are hard-coded in order to check for logic correctness of the generators. A shortened version of the csv data in the form of a string is used as input to the `SimpleAlertGenerator` in order for tests to always run on same data and easier to manually find expected anomalies. 

Some map/multimap implementations are changed to `LinkedHashMap` and `LinkedListMultimap` in order to maintain chronological order for the `Alert`s. Chronological order based on `Timestamp` is preferred for the `Anomaly` List within an `Alert` and for `Alert`s in a list of `Alert`s, so they can be stored in order within datastore and eventually sent in order to frontend. 