### PR TITLE
Adjust related data to process both metric and dimension + tests

### DIFF
--- a/backend/src/main/java/com/google/blackswan/mock/DummyRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyRelatedDataGenerator.java
@@ -35,7 +35,7 @@ public class DummyRelatedDataGenerator implements RelatedDataGenerator {
    * Input parameters are not used at all, since this implementation generates 
    * dummy related data objects that do not depend on input. 
    */
-  public ImmutableList<RelatedData> getRelatedData(String metricName, String dimensionName,
+  public ImmutableList<RelatedData> getRelatedData(DataInfo dataInfo,
       Timestamp startTimeInclusive, Timestamp endTimeInclusive) {
     return relatedDataList;
   }

--- a/backend/src/main/java/com/google/blackswan/mock/RelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/RelatedDataGenerator.java
@@ -22,6 +22,6 @@ import com.google.common.collect.ImmutableList;
  * metric/dimension and config in Datastore. 
  */
 public interface RelatedDataGenerator {  
-  ImmutableList<RelatedData> getRelatedData(String metricName, String dimensionName,
+  ImmutableList<RelatedData> getRelatedData(DataInfo dataInfo,
       Timestamp startTimeInclusive, Timestamp endTimeInclusive);
 }

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
@@ -104,13 +104,14 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
     }
 
     List<RelatedData> relatedDataList = SimpleRelatedDataGenerator.createGenerator()
-        .getRelatedData(metricName, dimensionName, 
+        .getRelatedData(DataInfo.of(metricName, dimensionName), 
                         listKeys.get(firstDataPointIndex),
                         listKeys.get(lastDataPointIndex));
 
     return new Anomaly(time, metricName, dimensionName, dataPoints, relatedDataList);
   }
 
+  /** TODO: Specify which metric and dimension data to look at for this generator. */
   public static SimpleAnomalyGenerator createGenerator() {
     return new SimpleAnomalyGenerator(
       SimpleAnomalyGenerator.class.getResourceAsStream(DATA_FILE_LOCATION),

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
@@ -57,7 +57,7 @@ public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
     if (relatedDataMap.containsKey(dataInfo)) {
       for (DataInfoUser relatedTopic : relatedDataMap.get(dataInfo)) {
         Map<Timestamp, MetricValue> dataPointsPlot = 
-            getDataPointsInRange(relatedTopic, startTime, endTime);
+            getDataPointsInRange(relatedTopic.getDataInfo(), startTime, endTime);
         
         if (dataPointsPlot.isEmpty()) {
           continue;

--- a/backend/src/main/java/com/google/models/DataInfo.java
+++ b/backend/src/main/java/com/google/models/DataInfo.java
@@ -19,7 +19,7 @@ package com.google.models;
  * Wrapper for meta data of a related data type used in RelatedDataGenerator.
  * This is an immutable class.  
  */
-public class DataInfo {
+public final class DataInfo {
   
   private final String metricName;
   private final String dimensionName;

--- a/backend/src/main/java/com/google/models/DataInfo.java
+++ b/backend/src/main/java/com/google/models/DataInfo.java
@@ -19,17 +19,18 @@ package com.google.models;
  * Wrapper for meta data of a related data type used in RelatedDataGenerator.
  * This is an immutable class.  
  */
-public final class DataInfo {
+public class DataInfo {
   
   private final String metricName;
   private final String dimensionName;
-  private final String username;
 
-  /** TODO: Change username to List to deal with multiple users requesting same related data. */
-  public DataInfo(String metricName, String dimensionName, String username) {
+  public static DataInfo of(String metricName, String dimensionName) {
+    return new DataInfo(metricName, dimensionName);
+  }
+
+  public DataInfo(String metricName, String dimensionName) {
     this.metricName = metricName;
     this.dimensionName = dimensionName;
-    this.username = username;
   }
 
   public String getMetricName() {
@@ -40,17 +41,17 @@ public final class DataInfo {
     return dimensionName;
   }
 
-  public String getUsername() {
-    return username;
-  }
-
   @Override
   public String toString() {
     return new StringBuilder()
         .append("Metric Name: ").append(metricName).append("\n")
         .append("Dimension Name: ").append(dimensionName).append("\n")
-        .append("Username: ").append(username).append("\n")
         .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return toString().hashCode();
   }
 
   @Override

--- a/backend/src/main/java/com/google/models/DataInfoUser.java
+++ b/backend/src/main/java/com/google/models/DataInfoUser.java
@@ -20,9 +20,10 @@ package com.google.models;
  * requests the data.
  * This is an immutable class.  
  */
-public class DataInfoUser extends DataInfo {
+public class DataInfoUser {
   
   private final String username;
+  private final DataInfo dataInfo;
 
   public static DataInfoUser of(String metricName, 
       String dimensionName, String username) {
@@ -31,8 +32,20 @@ public class DataInfoUser extends DataInfo {
 
   /** TODO: Change username to List to deal with multiple users requesting same related data. */
   public DataInfoUser(String metricName, String dimensionName, String username) {
-    super(metricName, dimensionName);
+    this.dataInfo = DataInfo.of(metricName, dimensionName);
     this.username = username;
+  }
+
+  public DataInfo getDataInfo() {
+    return dataInfo;
+  }
+
+  public String getMetricName() {
+    return dataInfo.getMetricName();
+  }
+
+  public String getDimensionName() {
+    return dataInfo.getDimensionName();
   }
 
   public String getUsername() {
@@ -40,15 +53,8 @@ public class DataInfoUser extends DataInfo {
   }
 
   @Override
-  public int hashCode() {
-    // Use parent's toString() in order for DataInfoUser and DataInfo 
-    // with same metric and dimension to have same hash code.  
-    return super.toString().hashCode();
-  }
-
-  @Override
   public String toString() {
-    return new StringBuilder(super.toString())
+    return new StringBuilder(dataInfo.toString())
         .append("Username: ").append(username).append("\n")
         .toString();
   }

--- a/backend/src/main/java/com/google/models/DataInfoUser.java
+++ b/backend/src/main/java/com/google/models/DataInfoUser.java
@@ -20,7 +20,7 @@ package com.google.models;
  * requests the data.
  * This is an immutable class.  
  */
-public class DataInfoUser {
+public final class DataInfoUser {
   
   private final String username;
   private final DataInfo dataInfo;

--- a/backend/src/main/java/com/google/models/DataInfoUser.java
+++ b/backend/src/main/java/com/google/models/DataInfoUser.java
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.models;
+
+
+/** 
+ * Wrapper for meta data of a related data type that includes user who
+ * requests the data.
+ * This is an immutable class.  
+ */
+public class DataInfoUser extends DataInfo {
+  
+  private final String username;
+
+  public static DataInfoUser of(String metricName, 
+      String dimensionName, String username) {
+    return new DataInfoUser(metricName, dimensionName, username);
+  }
+
+  /** TODO: Change username to List to deal with multiple users requesting same related data. */
+  public DataInfoUser(String metricName, String dimensionName, String username) {
+    super(metricName, dimensionName);
+    this.username = username;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  @Override
+  public int hashCode() {
+    // Use parent's toString() in order for DataInfoUser and DataInfo 
+    // with same metric and dimension to have same hash code.  
+    return super.toString().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return new StringBuilder(super.toString())
+        .append("Username: ").append(username).append("\n")
+        .toString();
+  }
+
+}

--- a/backend/src/test/java/com/google/models/DataInfoTest.java
+++ b/backend/src/test/java/com/google/models/DataInfoTest.java
@@ -77,7 +77,7 @@ public final class DataInfoTest {
   }
 
   @Test
-  public void equals_workingComparatorAndHashCodeBetParentAndChild() {
+  public void equals_workingComparatorAndHashCodeParentAndChild() {
     DataInfoUser diffUsername
         = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, "leodson@");
     DataInfoUser diffMetric

--- a/backend/src/test/java/com/google/models/DataInfoTest.java
+++ b/backend/src/test/java/com/google/models/DataInfoTest.java
@@ -1,0 +1,98 @@
+package com.google.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+
+/** Contain tests for methods in {@link DataInfo} and {@link DataInfoUser} class. */
+@RunWith(JUnit4.class)
+public final class DataInfoTest {
+  private static final String METRIC_NAME = "Interest Over Time";
+  private static final String DIMENSION_NAME = "Ramen";
+  private static final String USER_NAME = "catyu@";
+  private static final DataInfo DATA_INFO 
+      = new DataInfo(METRIC_NAME, DIMENSION_NAME);
+  private static final DataInfoUser DATA_INFO_USER 
+      = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, USER_NAME);
+
+  @Test
+  public void getMetricName_workingGetter() {
+    assertEquals(METRIC_NAME, DATA_INFO.getMetricName());
+  }
+
+  @Test
+  public void getDimensionName_workingGetter() {
+    assertEquals(DIMENSION_NAME, DATA_INFO.getDimensionName());
+  }
+
+  @Test
+  public void getUsername_workingGetter() {
+    assertEquals(USER_NAME, DATA_INFO_USER.getUsername());
+  }
+
+  @Test
+  public void equals_workingComparatorAndHashCode() {
+    DataInfo same = new DataInfo(METRIC_NAME, DIMENSION_NAME);
+    DataInfo diffMetric = new DataInfo("Country", DIMENSION_NAME);
+    DataInfo diffDimension = new DataInfo(METRIC_NAME, "Udon");
+
+    assertEquals(DATA_INFO, DATA_INFO);
+    assertEquals(DATA_INFO.hashCode(), DATA_INFO.hashCode());
+    assertEquals(DATA_INFO, same);
+    assertEquals(same, DATA_INFO);
+    assertEquals(DATA_INFO.hashCode(), same.hashCode());
+    assertFalse(DATA_INFO.equals(diffMetric));
+    assertFalse(DATA_INFO.hashCode() == diffMetric.hashCode());
+    assertFalse(DATA_INFO.equals(diffDimension));
+    assertFalse(DATA_INFO.hashCode() == diffDimension.hashCode());
+    assertFalse(DATA_INFO.equals(null));
+  }
+
+  @Test
+  public void equals_workingComparatorAndHashCodeChild() {
+    DataInfoUser diffUsername
+        = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, "leodson@");
+    DataInfoUser diffMetric
+        = new DataInfoUser("Country", DIMENSION_NAME, USER_NAME);
+
+    // DataInfoUser with different username but same metric and
+    // dimension should be equal. (Could change depending on future
+    // implementation for multiple user per DataInfoUser.)
+    assertEquals(DATA_INFO_USER, DATA_INFO_USER);
+    assertEquals(DATA_INFO_USER.hashCode(), DATA_INFO_USER.hashCode());
+    assertEquals(DATA_INFO_USER, diffUsername);
+    assertEquals(diffUsername, DATA_INFO_USER);
+    assertEquals(DATA_INFO_USER.hashCode(), diffUsername.hashCode());
+    assertFalse(DATA_INFO_USER.equals(diffMetric));
+    assertFalse(diffMetric.equals(DATA_INFO_USER));
+    assertFalse(DATA_INFO_USER.hashCode() == diffMetric.hashCode());
+  }
+
+  @Test
+  public void equals_workingComparatorAndHashCodeBetParentAndChild() {
+    DataInfoUser diffUsername
+        = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, "leodson@");
+    DataInfoUser diffMetric
+        = new DataInfoUser("Country", DIMENSION_NAME, USER_NAME);
+
+    // DataInfoUser with same metric and dimension should equal
+    // DataInfo with same metric and dimension.
+    assertEquals(DATA_INFO, DATA_INFO_USER);
+    assertEquals(DATA_INFO_USER, DATA_INFO);
+    assertEquals(DATA_INFO.hashCode(), DATA_INFO_USER.hashCode());
+    assertEquals(DATA_INFO, diffUsername);
+    assertEquals(DATA_INFO.hashCode(), diffUsername.hashCode());
+    assertFalse(DATA_INFO.equals(diffMetric));
+    assertFalse(diffMetric.equals(DATA_INFO));
+    assertFalse(DATA_INFO.hashCode() == diffMetric.hashCode());
+  }
+
+}

--- a/backend/src/test/java/com/google/models/DataInfoTest.java
+++ b/backend/src/test/java/com/google/models/DataInfoTest.java
@@ -19,9 +19,9 @@ public final class DataInfoTest {
   private static final String DIMENSION_NAME = "Ramen";
   private static final String USER_NAME = "catyu@";
   private static final DataInfo DATA_INFO 
-      = new DataInfo(METRIC_NAME, DIMENSION_NAME);
+      = DataInfo.of(METRIC_NAME, DIMENSION_NAME);
   private static final DataInfoUser DATA_INFO_USER 
-      = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, USER_NAME);
+      = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, USER_NAME);
 
   @Test
   public void getMetricName_workingGetter() {
@@ -40,9 +40,9 @@ public final class DataInfoTest {
 
   @Test
   public void equals_workingComparatorAndHashCode() {
-    DataInfo same = new DataInfo(METRIC_NAME, DIMENSION_NAME);
-    DataInfo diffMetric = new DataInfo("Country", DIMENSION_NAME);
-    DataInfo diffDimension = new DataInfo(METRIC_NAME, "Udon");
+    DataInfo same = DataInfo.of(METRIC_NAME, DIMENSION_NAME);
+    DataInfo diffMetric = DataInfo.of("Country", DIMENSION_NAME);
+    DataInfo diffDimension = DataInfo.of(METRIC_NAME, "Udon");
 
     assertEquals(DATA_INFO, DATA_INFO);
     assertEquals(DATA_INFO.hashCode(), DATA_INFO.hashCode());
@@ -59,9 +59,9 @@ public final class DataInfoTest {
   @Test
   public void equals_workingComparatorAndHashCodeChild() {
     DataInfoUser diffUsername
-        = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, "leodson@");
+        = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, "leodson@");
     DataInfoUser diffMetric
-        = new DataInfoUser("Country", DIMENSION_NAME, USER_NAME);
+        = DataInfoUser.of("Country", DIMENSION_NAME, USER_NAME);
 
     // DataInfoUser with different username but same metric and
     // dimension should be equal. (Could change depending on future
@@ -79,9 +79,9 @@ public final class DataInfoTest {
   @Test
   public void equals_workingComparatorAndHashCodeBetParentAndChild() {
     DataInfoUser diffUsername
-        = new DataInfoUser(METRIC_NAME, DIMENSION_NAME, "leodson@");
+        = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, "leodson@");
     DataInfoUser diffMetric
-        = new DataInfoUser("Country", DIMENSION_NAME, USER_NAME);
+        = DataInfoUser.of("Country", DIMENSION_NAME, USER_NAME);
 
     // DataInfoUser with same metric and dimension should equal
     // DataInfo with same metric and dimension.

--- a/backend/src/test/java/com/google/models/DataInfoTest.java
+++ b/backend/src/test/java/com/google/models/DataInfoTest.java
@@ -34,11 +34,6 @@ public final class DataInfoTest {
   }
 
   @Test
-  public void getUsername_workingGetter() {
-    assertEquals(USER_NAME, DATA_INFO_USER.getUsername());
-  }
-
-  @Test
   public void equals_workingComparatorAndHashCode() {
     DataInfo same = DataInfo.of(METRIC_NAME, DIMENSION_NAME);
     DataInfo diffMetric = DataInfo.of("Country", DIMENSION_NAME);
@@ -56,43 +51,16 @@ public final class DataInfoTest {
     assertFalse(DATA_INFO.equals(null));
   }
 
-  @Test
-  public void equals_workingComparatorAndHashCodeChild() {
-    DataInfoUser diffUsername
-        = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, "leodson@");
-    DataInfoUser diffMetric
-        = DataInfoUser.of("Country", DIMENSION_NAME, USER_NAME);
+  /** Tests for DataInfoUser class below. */
 
-    // DataInfoUser with different username but same metric and
-    // dimension should be equal. (Could change depending on future
-    // implementation for multiple user per DataInfoUser.)
-    assertEquals(DATA_INFO_USER, DATA_INFO_USER);
-    assertEquals(DATA_INFO_USER.hashCode(), DATA_INFO_USER.hashCode());
-    assertEquals(DATA_INFO_USER, diffUsername);
-    assertEquals(diffUsername, DATA_INFO_USER);
-    assertEquals(DATA_INFO_USER.hashCode(), diffUsername.hashCode());
-    assertFalse(DATA_INFO_USER.equals(diffMetric));
-    assertFalse(diffMetric.equals(DATA_INFO_USER));
-    assertFalse(DATA_INFO_USER.hashCode() == diffMetric.hashCode());
+  @Test
+  public void getUsername_workingGetter() {
+    assertEquals(USER_NAME, DATA_INFO_USER.getUsername());
   }
 
   @Test
-  public void equals_workingComparatorAndHashCodeParentAndChild() {
-    DataInfoUser diffUsername
-        = DataInfoUser.of(METRIC_NAME, DIMENSION_NAME, "leodson@");
-    DataInfoUser diffMetric
-        = DataInfoUser.of("Country", DIMENSION_NAME, USER_NAME);
-
-    // DataInfoUser with same metric and dimension should equal
-    // DataInfo with same metric and dimension.
-    assertEquals(DATA_INFO, DATA_INFO_USER);
-    assertEquals(DATA_INFO_USER, DATA_INFO);
-    assertEquals(DATA_INFO.hashCode(), DATA_INFO_USER.hashCode());
-    assertEquals(DATA_INFO, diffUsername);
-    assertEquals(DATA_INFO.hashCode(), diffUsername.hashCode());
-    assertFalse(DATA_INFO.equals(diffMetric));
-    assertFalse(diffMetric.equals(DATA_INFO));
-    assertFalse(DATA_INFO.hashCode() == diffMetric.hashCode());
+  public void getDataInfo_workingGetter() {
+    assertEquals(DATA_INFO, DATA_INFO_USER.getDataInfo());
   }
 
 }


### PR DESCRIPTION
**Summary:**
1) Addresses (#49) where related data generator only looks at dimension instead of both metric and dimension.
2) Create wrapper for metric and dimension value called: `DataInfo.java` and wrapper for metric, dimension, and username called: `DataInfoUser.java`
3) Add tests for `DataInfo.java` and `DataInfoUser.java`.

**Tests:**
Aside from tests mentioned above, tests for `RelatedDataGenerator`s are not written yet as I am waiting to be able to use config from datastore instead of hard coding configs. 

**Design Decisions:**
I chose to wrap metric name and dimension name within `DataInfo.java` class because for `relatedDataMap` which maps a specific type of data to other types of data to show, I don't just want to map `Ramen -> Udon, Rice`, I want to map `{Interest Level in US, Ramen} -> {Interest Level in JP, Udon}, {Interest Level in China, Rice}`. In addition, for future integration with more complicated data with multiple metric and multiple dimension, `DataInfo` class can easily be extended to fit those needs. 

I chose to have `DataInfoUser.java` class which should contain `metricName`, `dimensionName`, and `username` to have a private instance of `DataInfo.java` because `DataInfoUser` class should always contain all of the fields in `DataInfo` plus the additional `username` field. This way, whenever new fields are added to `DataInfo`, they can also be accessed through `DataInfoUser`. In addition, `DataInfo` can easily be extracted from `DataInfoUser` through a getter which allows the current `DataInfoUser` to behave the same fashion as a `DataInfo` class (i.e. having access to same comparators). 

I decided to not have `DataInfoUser` class be a children of `DataInfo` because (1) this way I cannot get an instance of `DataInfo` from `DataInfoUser` which is often use in my code when I use `DataInfo` as key to a map and would require me to define `hashCode` and `equal` for `DataInfoUser` (2) I want to adhere to the [`Composition over Inheritance`](https://en.wikipedia.org/wiki/Composition_over_inheritance) principle mentioned in Item 16 of _Effective Java_ (thank you @hehhjiang for bringing this principle to my attention!). 

In addition to the `constructor`s for both `DataInfo` and `DataInfoUser`, I added `static` create method `of` for both classes. This is because (1) it is more readable (ex. `new DataInfo(metric, dimension)` vs. `DataInfo.of(metric, dimension)`) (2) it is shorter to type (3) Effective Java Item 1 mentions that create methods named `of` should be used _for aggregation method that takes multiple parameters and returns an instance of this type that incorporates them_, which I think suits this case very well. 

**Quick Note:** Prior to this PR, `DataInfo` contains metric, dimension, and username, which is what `DataInfoUser` currently includes. The old uses of `DataInfo` is replaced with `DataInfoUser`. 