### PR TITLE
Enhance timestamp class to be stored as long in datastore to enable sorting 

### DIFF
--- a/backend/src/main/java/com/google/models/Alert.java
+++ b/backend/src/main/java/com/google/models/Alert.java
@@ -97,7 +97,7 @@ public final class Alert {
 
   public Entity toEntity() {
     Entity alertEntity = new Entity(ALERT_ENTITY_KIND);
-    alertEntity.setProperty(Timestamp.TIMESTAMP_PROPERTY, timestampDate.toString());
+    alertEntity.setProperty(Timestamp.TIMESTAMP_PROPERTY, timestampDate.toEpochDay());
     alertEntity.setProperty(STATUS_PROPERTY, status.name());
 
     List<EmbeddedEntity> list = anomalies.stream()
@@ -129,9 +129,7 @@ public final class Alert {
         .collect(ImmutableList.toImmutableList());
 
     return new Alert(
-      new Timestamp(
-        (String) alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY)
-      ), 
+      Timestamp.of((long) alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY)), 
       listAnomaly, 
       StatusType.valueOf((String) alertEntity.getProperty(STATUS_PROPERTY)),
       OptionalLong.of(alertEntity.getKey().getId())

--- a/backend/src/main/java/com/google/models/Timestamp.java
+++ b/backend/src/main/java/com/google/models/Timestamp.java
@@ -36,6 +36,10 @@ public final class Timestamp implements Comparable<Timestamp> {
                                                     .toFormatter();
 
   private final LocalDate date;
+
+  public static Timestamp of(long epochDay) {
+    return new Timestamp(LocalDate.ofEpochDay(epochDay));
+  }
  
   public Timestamp(int day, int month, int year) {
     date = LocalDate.of(year, month, day);
@@ -59,6 +63,10 @@ public final class Timestamp implements Comparable<Timestamp> {
 
   public int getYear() {
     return date.getYear();
+  }
+
+  public long toEpochDay() {
+    return date.toEpochDay();
   }
 
   @Override

--- a/backend/src/test/java/com/google/models/AlertTest.java
+++ b/backend/src/test/java/com/google/models/AlertTest.java
@@ -122,7 +122,7 @@ public final class AlertTest {
 
     assertEquals(anomalyList, alert.getAnomalies());
     assertEquals(alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY), 
-        alert.getTimestamp().toString());
+        alert.getTimestamp().toEpochDay());
     assertEquals(alertEntity.getProperty(Alert.STATUS_PROPERTY), 
         alert.getStatus().name());
   }

--- a/backend/src/test/java/com/google/models/TimestampTest.java
+++ b/backend/src/test/java/com/google/models/TimestampTest.java
@@ -20,6 +20,7 @@ public final class TimestampTest {
   private static final int MONTH_CONST = 1;
   private static final int YEAR_CONST = 2000;
   private static final Timestamp TIMESTAMP = new Timestamp(DAY_CONST, MONTH_CONST, YEAR_CONST);
+  private static final long EXPECTED_EPOCH_DAY = 10957;
 
   @Test
   public void constructor_convertStringToDate() {
@@ -60,6 +61,16 @@ public final class TimestampTest {
           String.format("%02d", DAY_CONST),
       TIMESTAMP.toString()
     );
+  }
+
+  @Test
+  public void toEpochDay_correctConversionFromDateToLong() {
+    assertEquals(EXPECTED_EPOCH_DAY, TIMESTAMP.toEpochDay());
+  }
+
+  @Test
+  public void ofEpochDay_correctConversionFromLongToDate() {
+    assertEquals(TIMESTAMP, Timestamp.of(EXPECTED_EPOCH_DAY));
   }
 
   @Test


### PR DESCRIPTION
**Summary:**
1) Address Issue (#50) where sorting within Datastore by timestamp was not enabled due to timestamp being stored as `String` within Datastore
2) Timestamp now stored as `long` (in form of [`EpochDay`](https://docs.oracle.com/javase/8/docs/api/java/time/temporal/ChronoField.html#EPOCH_DAY)) within Datastore which enables sorting and features like:
```
Query query = new Query(Alert.ALERT_ENTITY_KIND).addSort("timestamp", SortDirection.DESCENDING);
```
This allows `AlertManagement` to easily query for latest `Alert`s from the Datatore. This long conversion is only used when interfacing with the Datastore, its functionalities remain unchanged in all other places. 

**Tests:**
Added tests for `Timestamp` to test for correct conversion to `EpochDay` and conversion from `EpochDay` back to `Timestamp` object. Also, unofficially tested whether the query with sort example above worked correctly by printing out the json of `Alert`s in the datastore to check if they are in descending order by time. 

**Design Choices:**
`Timestamp` object composes of a `LocalDate` object that is imported from `java.time.LocalDate`. So to convert my `Timestamp` object to `long EpochDay`, I simply use the built-in `toEpochDay()` method of `LocalDate`. To convert from `long EpochDay` to my `Timestamp` object, I use the built-in `ofEpochDay(long ...)` of `LocalDate`. This way I do not have to implement the conversion myself and I simply added wrapper around these `LocalDate` functionalities in my `Timestamp` class.  

**Extra fun information (optional read lol):**

`EpochDay` is more commonly known as `unix time stamp`.  This count starts at the Unix Epoch on January 1st, 1970 at UTC. Here are some fun information about it ([source](https://www.unixtimestamp.com/index.php)):

_What happens on **January 19, 2038**?_

_On this date the Unix Time Stamp will **cease to work due to a 32-bit overflow.** Before this moment millions of applications will need to either adopt a new convention for time stamps or be migrated to 64-bit systems **which will buy the time stamp a "bit" more time**._

Note: I just wanted to include the extra information because I thought the overflow and pun at the end was kind of funny and maybe y'all will think it is funny too lol.
