### PR TITLE
Enhance detection of anomalies across multiple topics and add const class

### DIFF
--- a/backend/src/main/java/com/google/blackswan/mock/AdvanceAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/AdvanceAlertGenerator.java
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.blackswan.mock;
+
+import com.google.models.*;
+import java.util.List;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.LinkedListMultimap;
+
+/** Generate list of alerts of topics requested by grouping anomalies by their month. */
+public class AdvanceAlertGenerator implements AlertGenerator {
+
+  private final ImmutableList<Alert> alerts;
+
+  public AdvanceAlertGenerator(List<DataInfo> topics) {
+    this.alerts = groupAnomaliesToAlerts(topics);
+  }
+
+  private static ImmutableList<Alert> groupAnomaliesToAlerts(List<DataInfo> topics) {
+    List<Anomaly> anomaliesList = topics.stream()
+        .flatMap(topic -> SimpleAnomalyGenerator.createGenerator(topic).getAnomalies().stream())
+        .collect(ImmutableList.toImmutableList());
+    
+    ListMultimap<Timestamp, Anomaly> anomalyGroups = LinkedListMultimap.create();
+
+    // Group anomalies by month.
+    for (Anomaly currAnomaly : anomaliesList) {
+      Timestamp keyTimestamp = currAnomaly.getTimestamp().getFirstDayOfNextMonth();
+      anomalyGroups.put(keyTimestamp, currAnomaly);
+    }
+
+    return anomalyGroups.keySet().stream()
+        .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), Alert.StatusType.UNRESOLVED))
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  public List<Alert> getAlerts() {
+    return alerts;
+  }
+}

--- a/backend/src/main/java/com/google/blackswan/mock/AlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/AlertGenerator.java
@@ -14,7 +14,7 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.Alert;
 import java.util.List;
 
 /** Alert Generator that takes in an AnomalyGenerator and outputs lists of alerts. */

--- a/backend/src/main/java/com/google/blackswan/mock/AnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/AnomalyGenerator.java
@@ -14,7 +14,7 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.Anomaly;
 import java.util.List;
 
 /** Anomaly Generator that generates anomalies based on data provided. */

--- a/backend/src/main/java/com/google/blackswan/mock/CSVParser.java
+++ b/backend/src/main/java/com/google/blackswan/mock/CSVParser.java
@@ -16,7 +16,7 @@ package com.google.blackswan.mock;
 
 import static java.util.stream.Collectors.toMap;
 
-import com.google.models.*;
+import com.google.models.Timestamp;
 import java.util.Scanner;
 import java.util.Map;
 import java.util.LinkedHashMap;

--- a/backend/src/main/java/com/google/blackswan/mock/Const.java
+++ b/backend/src/main/java/com/google/blackswan/mock/Const.java
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.blackswan.mock;
+
+import com.google.models.DataInfo;
+import com.google.common.collect.ImmutableMap;
+
+public final class Const {
+  public static final String INTEREST_US = "Interest Over Time - US";
+  public static final String UDON = "Udon";
+  public static final String PHO = "Pho";
+  public static final String RAMEN = "Ramen";
+  // TODO: Add more const for other metrics.
+
+  public static final ImmutableMap<DataInfo, String> FILE_LOCATIONS 
+      = ImmutableMap.of(
+          DataInfo.of(INTEREST_US, UDON), "udon-data.csv",
+          DataInfo.of(INTEREST_US, PHO), "pho-data.csv",
+          DataInfo.of(INTEREST_US, RAMEN), "interest-ramen.csv"
+        );
+
+  // Cloud storage related constants.
+  public static final String KEY_LOCATION = "keys/key.json";
+  public static final String PROJECT_ID = "greyswan";
+  public static final String BUCKET_NAME = "greyswan.appspot.com";
+}

--- a/backend/src/main/java/com/google/blackswan/mock/Constant.java
+++ b/backend/src/main/java/com/google/blackswan/mock/Constant.java
@@ -17,7 +17,8 @@ package com.google.blackswan.mock;
 import com.google.models.DataInfo;
 import com.google.common.collect.ImmutableMap;
 
-public final class Const {
+/** Constants used throughout the blackswan mock classes. */
+public final class Constant {
   public static final String INTEREST_US = "Interest Over Time - US";
   public static final String UDON = "Udon";
   public static final String PHO = "Pho";
@@ -35,4 +36,7 @@ public final class Const {
   public static final String KEY_LOCATION = "keys/key.json";
   public static final String PROJECT_ID = "greyswan";
   public static final String BUCKET_NAME = "greyswan.appspot.com";
+
+  /** No instances. */
+  private Constant() {}
 }

--- a/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
@@ -14,8 +14,10 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
-import java.util.*;
+import com.google.models.Alert;
+import com.google.models.Timestamp;
+import java.util.List;
+import java.util.ArrayList;
 
 /** Generate list of dummy alerts. Supposed to analyze list of anomalies and create different alerts. */
 public class DummyAlertGenerator implements AlertGenerator {

--- a/backend/src/main/java/com/google/blackswan/mock/DummyAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyAnomalyGenerator.java
@@ -14,7 +14,7 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.Anomaly;
 import java.util.*;
 
 /** Generate list of hard-coded dummy anomalies. */

--- a/backend/src/main/java/com/google/blackswan/mock/DummyRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyRelatedDataGenerator.java
@@ -14,7 +14,9 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.RelatedData;
+import com.google.models.DataInfo;
+import com.google.models.Timestamp;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 

--- a/backend/src/main/java/com/google/blackswan/mock/MultiInputAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/MultiInputAlertGenerator.java
@@ -14,18 +14,24 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.DataInfo;
+import com.google.models.Anomaly;
+import com.google.models.Alert;
+import com.google.models.Timestamp;
 import java.util.List;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.LinkedListMultimap;
 
-/** Generate list of alerts of topics requested by grouping anomalies by their month. */
-public class AdvanceAlertGenerator implements AlertGenerator {
+/** 
+* Generate list of alerts of multiple topics requested by grouping 
+* anomalies by their month. 
+*/
+public class MultiInputAlertGenerator implements AlertGenerator {
 
   private final ImmutableList<Alert> alerts;
 
-  public AdvanceAlertGenerator(List<DataInfo> topics) {
+  public MultiInputAlertGenerator(List<DataInfo> topics) {
     this.alerts = groupAnomaliesToAlerts(topics);
   }
 
@@ -43,8 +49,8 @@ public class AdvanceAlertGenerator implements AlertGenerator {
     }
 
     return anomalyGroups.keySet().stream()
-        .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), Alert.StatusType.UNRESOLVED))
-        .collect(ImmutableList.toImmutableList());
+        .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), 
+            Alert.StatusType.UNRESOLVED)).collect(ImmutableList.toImmutableList());
   }
 
   public List<Alert> getAlerts() {

--- a/backend/src/main/java/com/google/blackswan/mock/RelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/RelatedDataGenerator.java
@@ -14,7 +14,9 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.RelatedData;
+import com.google.models.DataInfo;
+import com.google.models.Timestamp;
 import com.google.common.collect.ImmutableList;
 
 /** 

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
@@ -14,7 +14,9 @@
 
 package com.google.blackswan.mock;
 
-import com.google.models.*;
+import com.google.models.Anomaly;
+import com.google.models.Alert;
+import com.google.models.Timestamp;
 import java.util.List;
 import java.util.Collections;
 import com.google.common.collect.ImmutableList;

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
@@ -40,6 +40,8 @@ import com.google.blackswan.mock.filesystem.*;
 public class SimpleAnomalyGenerator implements AnomalyGenerator {
   private static final int THRESHOLD = 13;
   private static final int NUM_POINTS = 5;
+  /** Ideally the FileSystem should be injected. */
+  private static final FileSystem FILE_SYSTEM = LocalFileSystem.createSystem();
 
   private final ImmutableList<Anomaly> anomalies;
   private final DataInfo topic;
@@ -50,7 +52,7 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
       topic,
       // For [push] to git, always use LocalFileSystem, as CloudFileSystem will fail 
       // unit test without access to key.json. 
-      LocalFileSystem.createSystem().getDataAsStream(topic),
+      FILE_SYSTEM.getDataAsStream(topic),
       THRESHOLD,
       NUM_POINTS
     );

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAnomalyGenerator.java
@@ -33,53 +33,52 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.io.ByteArrayInputStream;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.blackswan.mock.filesystem.*;
 
 /** Generate list of anomalies based on data in the csv file using average and threshold. */
 public class SimpleAnomalyGenerator implements AnomalyGenerator {
-  private static final String DATA_FILE_LOCATION = "/sample-ramen-data.csv";
   private static final int THRESHOLD = 13;
   private static final int NUM_POINTS = 5;
-  private static final String DEFAULT_METRIC = "interest";
-  private static final String DEFAULT_DIMENSION = "ramen";
 
   private final ImmutableList<Anomaly> anomalies;
+  private final DataInfo topic;
+  private final ImmutableMap<Timestamp, Integer> data;
 
-  /** 
-   * TODO: Let generators take in parameters of dimension/metric names. 
-   *       Can also take in THRESHOLD and NUM_POINTS as parameters.
-   */
-  public static SimpleAnomalyGenerator createGenerator() {
+  public static SimpleAnomalyGenerator createGenerator(DataInfo topic) {
     return new SimpleAnomalyGenerator(
+      topic,
       // For [push] to git, always use LocalFileSystem, as CloudFileSystem will fail 
       // unit test without access to key.json. 
-      LocalFileSystem.createSystem().getDataAsStream(DEFAULT_METRIC, DEFAULT_DIMENSION),
+      LocalFileSystem.createSystem().getDataAsStream(topic),
       THRESHOLD,
       NUM_POINTS
     );
   }
 
   /** Use mainly in testing to have custom input as csv data. */
-  public static SimpleAnomalyGenerator createGeneratorWithString(String input, 
-      int threshold, int numDataPoints) {
+  public static SimpleAnomalyGenerator createGeneratorWithString(DataInfo topic,
+      String input, int threshold, int numDataPoints) {
     return new SimpleAnomalyGenerator(
+      topic,
       new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)),
       threshold,
       numDataPoints
     );
   }
 
-  private SimpleAnomalyGenerator(InputStream source, int threshold, 
+  private SimpleAnomalyGenerator(DataInfo topic, InputStream source, int threshold, 
       int numDataPoints) {
-    anomalies = generateAnomalies(CSVParser.parseCSV(source), threshold, numDataPoints);
+    this.topic = topic;
+    this.data = ImmutableMap.copyOf(CSVParser.parseCSV(source));
+    this.anomalies = generateAnomalies(threshold, numDataPoints);
   }
 
   public List<Anomaly> getAnomalies() {
     return anomalies;
   }
 
-  private static ImmutableList<Anomaly> generateAnomalies
-      (Map<Timestamp, Integer> data, int threshold, int numDataPoints) {
+  private ImmutableList<Anomaly> generateAnomalies(int threshold, int numDataPoints) {
     int avg = data.values().stream().reduce(0, Integer::sum) / data.size();
 
     // Find instances where exceed threshold.
@@ -96,7 +95,7 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
 
     // Create anomaly objects from those instances.
     return anomalyPoints.keySet().stream()
-        .map(key -> createAnomalyFromDataPoint(key, data, numDataPoints))
+        .map(key -> createAnomalyFromDataPoint(key, numDataPoints))
         .collect(ImmutableList.toImmutableList());
   }
 
@@ -104,11 +103,7 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
    * TODO: Depending on size of future data, alter algorithm of finding 
    * associated data points. 
    */
-  private static Anomaly createAnomalyFromDataPoint
-      (Timestamp time, Map<Timestamp, Integer> data, int numDataPoints) {
-    // TODO: Make const or obtain metric/dimension name from csv file.
-    String metricName = "Interest Over Time";
-    String dimensionName = "Ramen";
+  private Anomaly createAnomalyFromDataPoint(Timestamp time, int numDataPoints) {
 
     // Convert keys into ArrayList.
     List<Timestamp> listKeys = new ArrayList<Timestamp>(data.keySet());
@@ -132,11 +127,11 @@ public class SimpleAnomalyGenerator implements AnomalyGenerator {
     }
 
     List<RelatedData> relatedDataList = SimpleRelatedDataGenerator.createGenerator()
-        .getRelatedData(DataInfo.of(metricName, dimensionName), 
+        .getRelatedData(topic, 
                         listKeys.get(firstDataPointIndex),
                         listKeys.get(lastDataPointIndex));
 
-    return new Anomaly(time, metricName, dimensionName, dataPoints, relatedDataList);
+    return new Anomaly(time, topic.getMetricName(), topic.getDimensionName(), dataPoints, relatedDataList);
   }
 
 }

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
@@ -23,17 +23,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.ArrayListMultimap;
+import com.google.blackswan.mock.filesystem.*;
 
 /** Singleton class to generate related data for a given anomaly. */
 public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
-  private static final String TARGET_DIMENSION = "Ramen";
-  private static final String INTEREST_METRIC = "Interest Over Time";
   private static final String CONFIG_USERNAME = "catyu@";
-  // TODO: Replace FILE_LOCATIONS with a shared class that has map of metric to file names.
-  private static final ImmutableMap<DataInfo, String> FILE_LOCATIONS = ImmutableMap.of(
-                                                        DataInfo.of(INTEREST_METRIC, "Udon"), "/udon-data.csv",
-                                                        DataInfo.of(INTEREST_METRIC, "Pho"), "/pho-data.csv"
-                                                      );
 
   private static final SimpleRelatedDataGenerator INSTANCE = new SimpleRelatedDataGenerator();
 
@@ -81,17 +75,17 @@ public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
   private void prefillRelatedData() {
     // TODO: Replace with call for querying configs from datastore.
     // TODO: Deal with capitalizations when querying config from datastore.
-    relatedDataMap.put(DataInfo.of(INTEREST_METRIC, "Ramen"), 
-        DataInfoUser.of(INTEREST_METRIC, "Udon", CONFIG_USERNAME));
-    relatedDataMap.put(DataInfo.of(INTEREST_METRIC, "Ramen"), 
-        DataInfoUser.of(INTEREST_METRIC, "Pho", CONFIG_USERNAME));
+    relatedDataMap.put(DataInfo.of(Const.INTEREST_US, Const.RAMEN), 
+        DataInfoUser.of(Const.INTEREST_US, Const.UDON, CONFIG_USERNAME));
+    relatedDataMap.put(DataInfo.of(Const.INTEREST_US, Const.RAMEN), 
+        DataInfoUser.of(Const.INTEREST_US, Const.PHO, CONFIG_USERNAME));
     // Multimap looks like this right now: 
     // {{Interest Level, Ramen},{{Interest Level, Udon}, {Interest Level, Pho}}}, ...}.
   }
 
   private ImmutableMap<Timestamp, Integer> getTopicDataPoints(DataInfo topic) {
     return ImmutableMap.copyOf(csvDataCache.computeIfAbsent(topic, key -> CSVParser.parseCSV(
-        SimpleRelatedDataGenerator.class.getResourceAsStream(FILE_LOCATIONS.get(key))
+        LocalFileSystem.createSystem().getDataAsStream(topic)
       )));
   }
 

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
@@ -28,7 +28,8 @@ import com.google.blackswan.mock.filesystem.*;
 /** Singleton class to generate related data for a given anomaly. */
 public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
   private static final String CONFIG_USERNAME = "catyu@";
-
+  /** Ideally should be injected. Currently, putting as class variable. */
+  private static final FileSystem FILE_SYSTEM = LocalFileSystem.createSystem();
   private static final SimpleRelatedDataGenerator INSTANCE = new SimpleRelatedDataGenerator();
 
   private Multimap<DataInfo, DataInfoUser> relatedDataMap;
@@ -85,7 +86,7 @@ public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
 
   private ImmutableMap<Timestamp, Integer> getTopicDataPoints(DataInfo topic) {
     return ImmutableMap.copyOf(csvDataCache.computeIfAbsent(topic, key -> CSVParser.parseCSV(
-        LocalFileSystem.createSystem().getDataAsStream(topic)
+        FILE_SYSTEM.getDataAsStream(topic)
       )));
   }
 

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleRelatedDataGenerator.java
@@ -75,10 +75,10 @@ public class SimpleRelatedDataGenerator implements RelatedDataGenerator {
   private void prefillRelatedData() {
     // TODO: Replace with call for querying configs from datastore.
     // TODO: Deal with capitalizations when querying config from datastore.
-    relatedDataMap.put(DataInfo.of(Const.INTEREST_US, Const.RAMEN), 
-        DataInfoUser.of(Const.INTEREST_US, Const.UDON, CONFIG_USERNAME));
-    relatedDataMap.put(DataInfo.of(Const.INTEREST_US, Const.RAMEN), 
-        DataInfoUser.of(Const.INTEREST_US, Const.PHO, CONFIG_USERNAME));
+    relatedDataMap.put(DataInfo.of(Constant.INTEREST_US, Constant.RAMEN), 
+        DataInfoUser.of(Constant.INTEREST_US, Constant.UDON, CONFIG_USERNAME));
+    relatedDataMap.put(DataInfo.of(Constant.INTEREST_US, Constant.RAMEN), 
+        DataInfoUser.of(Constant.INTEREST_US, Constant.PHO, CONFIG_USERNAME));
     // Multimap looks like this right now: 
     // {{Interest Level, Ramen},{{Interest Level, Udon}, {Interest Level, Pho}}}, ...}.
   }

--- a/backend/src/main/java/com/google/blackswan/mock/filesystem/CloudFileSystem.java
+++ b/backend/src/main/java/com/google/blackswan/mock/filesystem/CloudFileSystem.java
@@ -21,7 +21,7 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.cloud.ReadChannel;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auth.oauth2.ServiceAccountCredentials;
-import com.google.models.*;
+import com.google.models.DataInfo;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -30,7 +30,7 @@ import com.google.cloud.storage.BlobId;
 import java.nio.channels.Channels;
 import java.io.InputStream;
 import java.util.logging.Logger;
-import com.google.blackswan.mock.Const;
+import com.google.blackswan.mock.Constant;
 
 /** Wrapper for Cloud Storage file system to access files in greyswan bucket. */
 public class CloudFileSystem implements FileSystem {
@@ -46,13 +46,13 @@ public class CloudFileSystem implements FileSystem {
     Storage cloudStorage;
     try {
       cloudStorage = StorageOptions.newBuilder()
-        .setProjectId(Const.PROJECT_ID)
+        .setProjectId(Constant.PROJECT_ID)
         .setCredentials(getCredentialsWithKey()).build()
         .getDefaultInstance().getService();
     } catch (IOException e) {
       log.warning(EXCEPTION_MESSAGE);
       cloudStorage = StorageOptions.newBuilder()
-        .setProjectId(Const.PROJECT_ID).build()
+        .setProjectId(Constant.PROJECT_ID).build()
         .getDefaultInstance().getService();
     }
     return new CloudFileSystem(cloudStorage);
@@ -67,15 +67,15 @@ public class CloudFileSystem implements FileSystem {
   }
 
   public InputStream getDataAsStream(DataInfo requestedData) {
-    Blob requestedFileBlob = storage.get(BlobId.of(Const.BUCKET_NAME, 
-        Const.FILE_LOCATIONS.get(requestedData)));
+    Blob requestedFileBlob = storage.get(BlobId.of(Constant.BUCKET_NAME, 
+        Constant.FILE_LOCATIONS.get(requestedData)));
 
     return Channels.newInputStream(requestedFileBlob.reader());
   }
 
   private static GoogleCredentials getCredentialsWithKey() throws IOException {
     File credentialsPath = new File(CloudFileSystem.class
-        .getClassLoader().getResource(Const.KEY_LOCATION).getFile());
+        .getClassLoader().getResource(Constant.KEY_LOCATION).getFile());
     if (!credentialsPath.exists()) {
       throw new IOException(EXCEPTION_MESSAGE);
     }

--- a/backend/src/main/java/com/google/blackswan/mock/filesystem/FileSystem.java
+++ b/backend/src/main/java/com/google/blackswan/mock/filesystem/FileSystem.java
@@ -15,7 +15,7 @@
 package com.google.blackswan.mock.filesystem;
 
 import java.io.InputStream;
-import com.google.models.*;
+import com.google.models.DataInfo;
 
 /** Interface for different file systems, ex. local vs cloud storage. */
 public interface FileSystem {

--- a/backend/src/main/java/com/google/blackswan/mock/filesystem/FileSystem.java
+++ b/backend/src/main/java/com/google/blackswan/mock/filesystem/FileSystem.java
@@ -15,11 +15,9 @@
 package com.google.blackswan.mock.filesystem;
 
 import java.io.InputStream;
+import com.google.models.*;
 
 /** Interface for different file systems, ex. local vs cloud storage. */
 public interface FileSystem {
-  public static final String DELIMITER = "-";
-  public static final String FILE_TYPE = ".csv";
-  
-  public InputStream getDataAsStream(String metric, String dimension);
+  public InputStream getDataAsStream(DataInfo requestedData);
 }

--- a/backend/src/main/java/com/google/blackswan/mock/filesystem/LocalFileSystem.java
+++ b/backend/src/main/java/com/google/blackswan/mock/filesystem/LocalFileSystem.java
@@ -14,8 +14,8 @@
 
 package com.google.blackswan.mock.filesystem;
 
-import com.google.models.*;
-import com.google.blackswan.mock.Const;
+import com.google.models.DataInfo;
+import com.google.blackswan.mock.Constant;
 import java.io.InputStream;
 import java.lang.ClassLoader;
 
@@ -36,7 +36,7 @@ public class LocalFileSystem implements FileSystem {
   }
 
   public InputStream getDataAsStream(DataInfo requestedData) {
-    return classLoader.getResourceAsStream(Const.FILE_LOCATIONS.get(requestedData));
+    return classLoader.getResourceAsStream(Constant.FILE_LOCATIONS.get(requestedData));
   }
 
 }

--- a/backend/src/main/java/com/google/blackswan/mock/filesystem/LocalFileSystem.java
+++ b/backend/src/main/java/com/google/blackswan/mock/filesystem/LocalFileSystem.java
@@ -14,6 +14,8 @@
 
 package com.google.blackswan.mock.filesystem;
 
+import com.google.models.*;
+import com.google.blackswan.mock.Const;
 import java.io.InputStream;
 import java.lang.ClassLoader;
 
@@ -33,10 +35,8 @@ public class LocalFileSystem implements FileSystem {
     this.classLoader = loader;
   }
 
-  public InputStream getDataAsStream(String metric, String dimension) {
-    String fileName = new StringBuilder(metric).append(FileSystem.DELIMITER)
-        .append(dimension).append(FileSystem.FILE_TYPE).toString();
-    return classLoader.getResourceAsStream(fileName);
+  public InputStream getDataAsStream(DataInfo requestedData) {
+    return classLoader.getResourceAsStream(Const.FILE_LOCATIONS.get(requestedData));
   }
 
 }

--- a/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
+++ b/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
@@ -20,8 +20,11 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.logging.Logger;
-import com.google.blackswan.mock.*;
+import com.google.blackswan.mock.Constant;
+import com.google.blackswan.mock.AlertGenerator;
+import com.google.blackswan.mock.MultiInputAlertGenerator;
 import com.google.models.Alert;
+import com.google.models.DataInfo;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
@@ -30,7 +33,6 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.common.collect.ImmutableList;
-import com.google.models.DataInfo;
 
 /**
 * Servlet to run cron job that generates Alerts to store in the datastore.
@@ -39,7 +41,7 @@ import com.google.models.DataInfo;
 public class CronServlet extends HttpServlet {
   private static final Logger log = Logger.getLogger(CronServlet.class.getName());
   private static final ImmutableList<DataInfo> ANOMALY_TYPES 
-      = ImmutableList.of(DataInfo.of(Const.INTEREST_US, Const.RAMEN));
+      = ImmutableList.of(DataInfo.of(Constant.INTEREST_US, Constant.RAMEN));
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -68,7 +70,7 @@ public class CronServlet extends HttpServlet {
 
   /** Store alerts from simpleGenerator into the datastore. */
   private void storeAlertsInDatastoreSimple() {
-    AlertGenerator simpleGenerator = new AdvanceAlertGenerator(ANOMALY_TYPES);
+    AlertGenerator simpleGenerator = new MultiInputAlertGenerator(ANOMALY_TYPES);
     simpleGenerator.getAlerts().forEach(alert -> {
       DatastoreServiceFactory.getDatastoreService().put(alert.toEntity());
     });

--- a/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
+++ b/backend/src/main/java/com/google/blackswan/servlets/CronServlet.java
@@ -29,6 +29,8 @@ import com.google.appengine.api.datastore.PreparedQuery;
 import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.models.DataInfo;
 
 /**
 * Servlet to run cron job that generates Alerts to store in the datastore.
@@ -36,6 +38,8 @@ import com.google.appengine.api.datastore.KeyFactory;
 @WebServlet("/blackswan/test")
 public class CronServlet extends HttpServlet {
   private static final Logger log = Logger.getLogger(CronServlet.class.getName());
+  private static final ImmutableList<DataInfo> ANOMALY_TYPES 
+      = ImmutableList.of(DataInfo.of(Const.INTEREST_US, Const.RAMEN));
   
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -64,7 +68,7 @@ public class CronServlet extends HttpServlet {
 
   /** Store alerts from simpleGenerator into the datastore. */
   private void storeAlertsInDatastoreSimple() {
-    AlertGenerator simpleGenerator = new SimpleAlertGenerator(SimpleAnomalyGenerator.createGenerator());
+    AlertGenerator simpleGenerator = new AdvanceAlertGenerator(ANOMALY_TYPES);
     simpleGenerator.getAlerts().forEach(alert -> {
       DatastoreServiceFactory.getDatastoreService().put(alert.toEntity());
     });

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
@@ -41,6 +41,7 @@ public class SimpleAlertGeneratorTest {
   private static final int EXPECTED_ALERT_SIZE = 2;
   private static final AlertGenerator ALERT_GENERATOR = new SimpleAlertGenerator(
     SimpleAnomalyGenerator.createGeneratorWithString(
+      DataInfo.of(METRIC_NAME, DIMENSION_NAME),
       MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
       SET_THRESHOLD_LOW, SET_DATAPOINTS
     )

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAnomalyGeneratorTest.java
@@ -58,6 +58,7 @@ public class SimpleAnomalyGeneratorTest {
   @Test
   public void getAnomalies_returnsListOfAnomaliesWithSizeOne() {
     anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
+      DataInfo.of(METRIC_NAME, DIMENSION_NAME),
       MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
       SET_THRESHOLD_HIGH, SET_DATAPOINTS
     );
@@ -82,6 +83,7 @@ public class SimpleAnomalyGeneratorTest {
   @Test
   public void getAnomalies_returnsListOfAnomaliesWithSizeTwo() {
     anomalyGenerator = SimpleAnomalyGenerator.createGeneratorWithString(
+      DataInfo.of(METRIC_NAME, DIMENSION_NAME),
       MockTestHelper.inputForAnomalyGenerator(SAMPLE_DATA), 
       SET_THRESHOLD_LOW, SET_DATAPOINTS
     );

--- a/backend/src/test/java/com/google/blackswan/mock/filesystem/CloudFileSystemTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/filesystem/CloudFileSystemTest.java
@@ -19,6 +19,7 @@ import org.mockito.MockitoAnnotations;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
+import com.google.models.DataInfo;
 
 
 /** Contain tests for methods in {@link CloudFileSystem} class. */
@@ -28,8 +29,8 @@ public class CloudFileSystemTest {
   @Mock Blob MOCK_BLOB;
 
   private static final String EXPECTED_BUCKET_NAME = "greyswan.appspot.com";
-  private static final String METRIC = "interest";
-  private static final String DIMENSION = "ramen";
+  private static final String METRIC = "Interest Over Time - US";
+  private static final String DIMENSION = "Ramen";
   private static final String EXPECTED_OBJECT_NAME = "interest-ramen.csv";
 
   @Before
@@ -51,7 +52,7 @@ public class CloudFileSystemTest {
     // Try finally block is necessary or else test will exit before reaching verify
     // statement. 
     try {
-      system.getDataAsStream(METRIC, DIMENSION);
+      system.getDataAsStream(DataInfo.of(METRIC, DIMENSION));
     } finally {
       verify(MOCK_STORAGE).get(BlobId.of(EXPECTED_BUCKET_NAME, EXPECTED_OBJECT_NAME));
     }

--- a/backend/src/test/java/com/google/blackswan/mock/filesystem/LocalFileSystemTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/filesystem/LocalFileSystemTest.java
@@ -16,7 +16,7 @@ import org.mockito.MockitoAnnotations;
 
 import java.lang.ClassLoader;
 import java.io.InputStream;
-
+import com.google.models.DataInfo;
 
 /** Contain tests for methods in {@link LocalFileSystem} class. */
 @RunWith(JUnit4.class)
@@ -24,8 +24,8 @@ public class LocalFileSystemTest {
   @Mock ClassLoader LOADER;
   @Mock InputStream INPUT_STREAM;
 
-  private static final String METRIC = "interest";
-  private static final String DIMENSION = "ramen";
+  private static final String METRIC = "Interest Over Time - US";
+  private static final String DIMENSION = "Ramen";
   private static final String EXPECTED_NAME = "interest-ramen.csv";
 
   @Before
@@ -38,7 +38,7 @@ public class LocalFileSystemTest {
   public void testGetDataAsStream_correctFileName() {
     LocalFileSystem system = LocalFileSystem.createSystemForTest(LOADER);
 
-    system.getDataAsStream(METRIC, DIMENSION);
+    system.getDataAsStream(DataInfo.of(METRIC, DIMENSION));
 
     verify(LOADER).getResourceAsStream(EXPECTED_NAME);
   }


### PR DESCRIPTION
**Summary:**
1) Address Issue (#58) which allows clients of Anomaly and Alert generator to specify a list of `DataInfo` (i.e. metric-dimension pairs) to detect anomalies in by altering `SimpleAnomalyGenerator` and adding `AdvanceAlertGenerator` implementation of `AlertGenerator`.
2) Add a `Const.java` class for miscellaneous shared constants that was spread out in many files.

**Tests:**
Not yet written for `AdvanceAlertGenerator`, will add that as soon as I am done. I also unofficially tested it by printing out the `Alert`s generated by `AdvanceAlertGenerator` to see if it correctly includes anomalies from all the types of data I specified.

**Design Choices:**
I chose to add the `AdvanceAlertGenerator` instead of simply altering the existing `SimpleAlertGenerator` because I think it is good to keep the simple implementation that focuses on grouping anomalies from one type of data and have the more advanced implementation with multiple type of data in `AdvanceAlertGenerator`.

In the `Const.java` file, I chose to have string representations of different metric and dimension names that is going to be used as part of Alerts/Anomalies in the Datastore and then used in the frontend as display to help synchronize the capitalization and wording across the entire blackswan mock service. I considered using `Enums` as a form of representation of metric/dimension names, but I realize that in order to have for example `INTEREST_US` print out to be the string `Interest Over Time - US`, I will need to add a custom `toString()` method for every type in the `Enum`. For now, I think it is simpler just to use strings.

**Note:**
Paula pointed out that a lot of time I import `com.google.models.*` when I don't use all of the models, so I have fixed them with this PR as well. That is the reason why so many files are changed. Most of them are just one line changes for imports!