### PR TITLE
Add priority to alert model, add sorting in display of Alerts page

### DIFF
--- a/backend/src/main/java/com/google/backend/servlets/AlertVisualizationServlet.java
+++ b/backend/src/main/java/com/google/backend/servlets/AlertVisualizationServlet.java
@@ -21,6 +21,7 @@ import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.gson.Gson;
 import com.google.models.Alert;
+import java.io.BufferedReader;
 import java.io.IOException;
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
@@ -28,9 +29,16 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-/** Servlet that returns data for requested specific Alert. */
+/**
+ * Servlet that handles specific Alert data. 
+ * Returns data for requested specific Alert and returns JSON.
+ * Given user input, changes Alert priority in the Datastore. 
+ */
 @WebServlet("/api/v1/alert-visualization")
 public class AlertVisualizationServlet extends HttpServlet {
+
+  private static final String EMPTY_BODY_ERROR = "No data was sent in HTTP request body.";
+  private static final String WRONG_ALERT_DATA = "Incorrect alert data sent in HTTP request.";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) 
@@ -45,5 +53,40 @@ public class AlertVisualizationServlet extends HttpServlet {
     } catch (EntityNotFoundException e) {
       throw new ServletException(e);
     }
+  }
+  
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) 
+      throws ServletException, IOException {
+    String[] data = processRequestBody(request);
+    Long id = Long.parseLong(data[0]);
+    String priority = data[1];
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    try {
+      Entity alertEntity = datastore.get(KeyFactory.createKey(Alert.ALERT_ENTITY_KIND, id));
+      alertEntity.setProperty(Alert.PRIORITY_PROPERTY, priority);
+      datastore.put(alertEntity);
+    } catch (EntityNotFoundException e) {
+      throw new ServletException(e);
+    }
+  }
+
+  /** 
+    * Read from the request body, which contains data in the format "alertId statusToChangeTo".
+    * For example, the body could be "4785074604081152 RESOLVED".
+    */
+  private String[] processRequestBody(HttpServletRequest request) 
+      throws IOException, ServletException {
+    BufferedReader reader = request.getReader();
+    String body = reader.readLine();
+    if (body == null) {
+      throw new ServletException(EMPTY_BODY_ERROR);
+    }
+    String[] data = body.split(" "); 
+    if (data.length != 2) {
+      throw new ServletException(WRONG_ALERT_DATA);
+    }
+    return data;
   }
 }

--- a/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/DummyAlertGenerator.java
@@ -29,7 +29,7 @@ public class DummyAlertGenerator implements AlertGenerator {
     alerts = new ArrayList<Alert>();
     for (int k = 0; k < SET_ALERT_GROUP_SIZE; k++) {
       alerts.add(Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(k), 
-          anomalyGenerator.getAnomalies(), Alert.StatusType.UNRESOLVED));
+          anomalyGenerator.getAnomalies(), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2));
     }
   }
 

--- a/backend/src/main/java/com/google/blackswan/mock/MultiInputAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/MultiInputAlertGenerator.java
@@ -50,7 +50,7 @@ public class MultiInputAlertGenerator implements AlertGenerator {
 
     return anomalyGroups.keySet().stream()
         .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), 
-            Alert.StatusType.UNRESOLVED)).collect(ImmutableList.toImmutableList());
+            Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2)).collect(ImmutableList.toImmutableList());
   }
 
   public List<Alert> getAlerts() {

--- a/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
+++ b/backend/src/main/java/com/google/blackswan/mock/SimpleAlertGenerator.java
@@ -44,7 +44,7 @@ public class SimpleAlertGenerator implements AlertGenerator {
     }
 
     return anomalyGroups.keySet().stream()
-        .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), Alert.StatusType.UNRESOLVED))
+        .map(key -> Alert.createAlertWithoutId(key, anomalyGroups.get(key), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2))
         .collect(ImmutableList.toImmutableList());
   }
 

--- a/backend/src/main/java/com/google/models/Alert.java
+++ b/backend/src/main/java/com/google/models/Alert.java
@@ -27,10 +27,16 @@ import java.util.OptionalLong;
 public final class Alert {
   public static final String ALERT_ENTITY_KIND = "alert";
   public static final String STATUS_PROPERTY = "status";
+  public static final String PRIORITY_PROPERTY = "priority";
   public static final String ANOMALIES_LIST_PROPERTY = "anomaliesList";
   public static enum StatusType {
     RESOLVED,
     UNRESOLVED
+  };
+  public static enum PriorityLevel {
+    P0,
+    P1,
+    P2
   };
 
   private static final long DEFAULT_ID = 0L;
@@ -39,11 +45,14 @@ public final class Alert {
   private final ImmutableList<Anomaly> anomalies;
   private final OptionalLong id;
   private StatusType status;
+  private PriorityLevel priority;
 
-  private Alert(Timestamp timestampDate, List<Anomaly> anomalies, StatusType status, OptionalLong id) {
+  private Alert(Timestamp timestampDate, List<Anomaly> anomalies, StatusType status, 
+      PriorityLevel priority, OptionalLong id) {
     this.timestampDate = timestampDate;
     this.anomalies = ImmutableList.copyOf(anomalies);
     this.status = status;
+    this.priority = priority;
     this.id = id;
   }
 
@@ -59,6 +68,10 @@ public final class Alert {
     return status;
   }
 
+  public PriorityLevel getPriority() {
+    return priority;
+  }
+
   public long getAlertId() {
     return id.orElse(DEFAULT_ID);
   }
@@ -72,6 +85,7 @@ public final class Alert {
     StringBuilder str = new StringBuilder()
         .append("Timestamp: ").append(timestampDate).append("\n")
         .append("Status: ").append(status.name()).append("\n")
+        .append("Priority: ").append(priority.name()).append("\n")
         .append("Anomalies: \n");
     anomalies.forEach(str::append);
     return str.toString();
@@ -91,6 +105,7 @@ public final class Alert {
 
     return target.timestampDate.equals(timestampDate) 
         && target.status.equals(status)
+        && target.priority.equals(priority)
         && target.anomalies.equals(anomalies)
         && target.getAlertId() == getAlertId();
   }
@@ -99,6 +114,7 @@ public final class Alert {
     Entity alertEntity = new Entity(ALERT_ENTITY_KIND);
     alertEntity.setProperty(Timestamp.TIMESTAMP_PROPERTY, timestampDate.toEpochDay());
     alertEntity.setProperty(STATUS_PROPERTY, status.name());
+    alertEntity.setProperty(PRIORITY_PROPERTY, priority.name());
 
     List<EmbeddedEntity> list = anomalies.stream()
         .map(Anomaly::toEmbeddedEntity)
@@ -111,8 +127,8 @@ public final class Alert {
 
   /** Used when an alert is first created and not converted from an entity. */
   public static Alert createAlertWithoutId(Timestamp timestampDate, 
-      List<Anomaly> anomalies, StatusType status) {
-    return new Alert(timestampDate, anomalies, status, OptionalLong.empty());
+      List<Anomaly> anomalies, StatusType status, PriorityLevel priority) {
+    return new Alert(timestampDate, anomalies, status, priority, OptionalLong.empty());
   }
 
   @SuppressWarnings("unchecked")
@@ -132,6 +148,7 @@ public final class Alert {
       Timestamp.of((long) alertEntity.getProperty(Timestamp.TIMESTAMP_PROPERTY)), 
       listAnomaly, 
       StatusType.valueOf((String) alertEntity.getProperty(STATUS_PROPERTY)),
+      PriorityLevel.valueOf((String) alertEntity.getProperty(PRIORITY_PROPERTY)),
       OptionalLong.of(alertEntity.getKey().getId())
     );
   }

--- a/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
+++ b/backend/src/test/java/com/google/backend/servlets/AlertsDataServletTest.java
@@ -84,7 +84,7 @@ public class AlertsDataServletTest {
   public void doGet_ReturnsAlertEntityAsJson() throws IOException, ServletException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Alert newAlert = Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(0), 
-        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED);
+        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2);
     datastore.put(newAlert.toEntity());
     // The new alert needs to be queried from the datastore in order to contain a valid id. 
     Query query = new Query(Alert.ALERT_ENTITY_KIND);
@@ -105,11 +105,11 @@ public class AlertsDataServletTest {
   public void doGet_ReturnsLimitedNumberOfSortedAlerts() throws IOException, ServletException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Alert newAlertOne = Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(0), 
-        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED);
+        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2);
     Alert newAlertTwo = Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(1), 
-        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED);
+        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2);
     Alert newAlertThree = Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(2), 
-        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED);
+        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2);
     datastore.put(newAlertOne.toEntity());
     datastore.put(newAlertTwo.toEntity());
     datastore.put(newAlertThree.toEntity());
@@ -140,7 +140,7 @@ public class AlertsDataServletTest {
   public void doPost_ChangesAlertStatusInDatastore() throws IOException, ServletException {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Alert newAlert = Alert.createAlertWithoutId(Timestamp.getDummyTimestamp(0), 
-        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED);
+        Arrays.asList(Anomaly.getDummyAnomaly()), Alert.StatusType.UNRESOLVED, Alert.PriorityLevel.P2);
     Entity newAlertEntity = newAlert.toEntity();
     datastore.put(newAlertEntity);
     Long id = newAlertEntity.getKey().getId();

--- a/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
+++ b/backend/src/test/java/com/google/blackswan/mock/SimpleAlertGeneratorTest.java
@@ -75,7 +75,8 @@ public class SimpleAlertGeneratorTest {
     Alert expectedAlertJuly = Alert.createAlertWithoutId(
       new Timestamp("2019-08-01"), 
       Arrays.asList(expectedAnomalyGroup1), 
-      Alert.StatusType.UNRESOLVED
+      Alert.StatusType.UNRESOLVED,
+      Alert.PriorityLevel.P2
     );
     // Create second expected alert which contains two anomalies that occurs in August. 
     ImmutableMap<Timestamp, MetricValue> expectedDataPoints2 = ImmutableMap.of(
@@ -102,7 +103,8 @@ public class SimpleAlertGeneratorTest {
     Alert expectedAlertAugust = Alert.createAlertWithoutId(
       new Timestamp("2019-09-01"), 
       Arrays.asList(expectedAnomalyGroup2_1, expectedAnomalyGroup2_2), 
-      Alert.StatusType.UNRESOLVED
+      Alert.StatusType.UNRESOLVED,
+      Alert.PriorityLevel.P2
     );
 
     List<Alert> generatedAlerts = ALERT_GENERATOR.getAlerts();

--- a/backend/src/test/java/com/google/models/AlertTest.java
+++ b/backend/src/test/java/com/google/models/AlertTest.java
@@ -39,7 +39,8 @@ public final class AlertTest {
     alert = Alert.createAlertWithoutId(
       Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
       dummyAnomalyGenerator.getAnomalies(), 
-      Alert.StatusType.UNRESOLVED
+      Alert.StatusType.UNRESOLVED,
+      Alert.PriorityLevel.P2
     );
   }
 
@@ -66,6 +67,11 @@ public final class AlertTest {
   }
 
   @Test
+  public void getPriority_workingGetter() {
+    assertEquals(alert.getPriority(), Alert.PriorityLevel.P2);
+  }
+
+  @Test
   public void getAlertId_workingGetter() {
     assertEquals(alert.getAlertId(), DEFAULT_ID);
   }
@@ -82,17 +88,26 @@ public final class AlertTest {
     Alert sameAlert = Alert.createAlertWithoutId(
         Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
         dummyAnomalyGenerator.getAnomalies(), 
-        Alert.StatusType.UNRESOLVED
+        Alert.StatusType.UNRESOLVED,
+        Alert.PriorityLevel.P2
       );
     Alert diffTimeAlert = Alert.createAlertWithoutId(
         Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT + 1), 
         dummyAnomalyGenerator.getAnomalies(), 
-        Alert.StatusType.UNRESOLVED
+        Alert.StatusType.UNRESOLVED,
+        Alert.PriorityLevel.P2
       );
     Alert diffResolveAlert = Alert.createAlertWithoutId(
         Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
         dummyAnomalyGenerator.getAnomalies(), 
-        Alert.StatusType.RESOLVED
+        Alert.StatusType.RESOLVED,
+        Alert.PriorityLevel.P2
+      );
+    Alert diffPriorityAlert = Alert.createAlertWithoutId(
+        Timestamp.getDummyTimestamp(TIMESTAMP_CONSTANT), 
+        dummyAnomalyGenerator.getAnomalies(), 
+        Alert.StatusType.UNRESOLVED,
+        Alert.PriorityLevel.P0
       );
     // TODO: Test equals with Alert object that has different list of anomalies. 
     //       Currently, dummyAnomalyGenerator can only generate one list of 
@@ -102,6 +117,7 @@ public final class AlertTest {
     assertTrue(alert.equals(sameAlert));
     assertFalse(alert.equals(diffTimeAlert));
     assertFalse(alert.equals(diffResolveAlert));
+    assertFalse(alert.equals(diffPriorityAlert));
     assertFalse(alert.equals(null));
   }
 
@@ -125,6 +141,8 @@ public final class AlertTest {
         alert.getTimestamp().toEpochDay());
     assertEquals(alertEntity.getProperty(Alert.STATUS_PROPERTY), 
         alert.getStatus().name());
+    assertEquals(alertEntity.getProperty(Alert.PRIORITY_PROPERTY), 
+        alert.getPriority().name());
   }
 
   @Test

--- a/frontend/src/AlertsManagement/AlertInfo.js
+++ b/frontend/src/AlertsManagement/AlertInfo.js
@@ -3,6 +3,7 @@ import { Line } from 'react-chartjs-2';
 import { Link } from 'react-router-dom';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
+import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -89,35 +90,41 @@ class AlertInfo extends Component {
         <Typography variant="h5" align="center">
           Alert on {alert.timestampDate}
         </Typography>
-        <Typography variant="h6" align="center">
-          Status: {alert.status}
-        </Typography>
-        <center>
-          <Button id="status-button" variant="contained" color="primary" component="span" 
-            onClick={this.handleStatusChange}
-          >
-            {alert.status === UNRESOLVED_STATUS ? "Resolve?" : "Unresolve?"}
-          </Button>
-        </center>
 
-        <Typography variant="h6" align="center">
-          Priority: P{priority}
-        </Typography>
-        <center>
-          <form>
-            <Select
-              labelId="priority-select"
-              id="priority-select"
-              value={priority}
-              onChange={event => this.handlePriorityChange(event.target.value)}
-            >
-              <MenuItem value={priorityLevels.P0}>P0</MenuItem>
-              <MenuItem value={priorityLevels.P1}>P1</MenuItem>
-              <MenuItem value={priorityLevels.P2}>P2</MenuItem>
-            </Select>
-          </form>
-        </center>
-
+        <Grid container justify="center">
+          <Grid item xs={2.5}>
+            <Typography variant="h6" align="center">
+              Status: {alert.status}
+            </Typography>
+            <center>
+              <Button id="status-button" variant="contained" color="primary" component="span" 
+                onClick={this.handleStatusChange}
+              >
+                {alert.status === UNRESOLVED_STATUS ? "Resolve?" : "Unresolve?"}
+              </Button>
+            </center>
+          </Grid>
+          <Grid item xs={2}>
+            <Typography variant="h6" align="center">
+              Priority: P{priority}
+            </Typography>
+            <center>
+              <form>
+                <Select
+                  labelId="priority-select"
+                  id="priority-select"
+                  value={priority}
+                  onChange={event => this.handlePriorityChange(event.target.value)}
+                >
+                  <MenuItem value={priorityLevels.P0}>P0</MenuItem>
+                  <MenuItem value={priorityLevels.P1}>P1</MenuItem>
+                  <MenuItem value={priorityLevels.P2}>P2</MenuItem>
+                </Select>
+              </form>
+            </center>
+          </Grid>
+        </Grid>
+ 
         <List className="anomalies-list">
           {alert.anomalies.map((anomaly, index) => {
             const chartData = {

--- a/frontend/src/AlertsManagement/AlertInfo.js
+++ b/frontend/src/AlertsManagement/AlertInfo.js
@@ -7,10 +7,12 @@ import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import Typography from '@material-ui/core/Typography';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { getSpecificAlertData } from './management_helpers';
-import { UNRESOLVED_STATUS, RESOLVED_STATUS } from './management_constants';
+import { UNRESOLVED_STATUS, RESOLVED_STATUS, priorityLevels } from './management_constants';
 
 /**
  * Requests alert data given specified alert ID from route and 
@@ -21,6 +23,7 @@ class AlertInfo extends Component {
     super(props);
     this.state = {
       alert: null,
+      priority: null,
     }
   }
 
@@ -30,7 +33,7 @@ class AlertInfo extends Component {
     if (result === null) {
       throw new Error("Could not find alert with id " + this.props.match.params.alertId);
     }
-    this.setState({ alert: result });
+    this.setState({ alert: result, priority: priorityLevels[result.priority] });
   }
 
   handleStatusChange = () => {
@@ -46,6 +49,22 @@ class AlertInfo extends Component {
     newAlert.status = statusToChangeTo;
     this.setState({ alert: newAlert });
   }
+
+  handlePriorityChange = (newPriority) => {
+    const { alert } = this.state;
+
+    // We have to get the P0, P1, or P2 version to match with enum representation in backend.
+    const numToEnum = Object.keys(priorityLevels)[Object.values(priorityLevels).indexOf(newPriority)];
+    fetch('/api/v1/alert-visualization', {
+      method: 'POST',
+      body: alert.id + " " + numToEnum,
+    });
+
+    const newAlert = Object.assign({}, alert);
+    newAlert.priority = newPriority;
+
+    this.setState({ alert: newAlert, priority: newPriority});
+  }
   
   render() {
     const style = {
@@ -53,7 +72,7 @@ class AlertInfo extends Component {
       marginBottom: '20px',
     };
 
-    const { alert } = this.state;
+    const { alert, priority } = this.state;
 
     if (!alert) {
       return <div />;
@@ -71,7 +90,7 @@ class AlertInfo extends Component {
           Alert on {alert.timestampDate}
         </Typography>
         <Typography variant="h6" align="center">
-            Status: {alert.status}
+          Status: {alert.status}
         </Typography>
         <center>
           <Button id="status-button" variant="contained" color="primary" component="span" 
@@ -80,6 +99,25 @@ class AlertInfo extends Component {
             {alert.status === UNRESOLVED_STATUS ? "Resolve?" : "Unresolve?"}
           </Button>
         </center>
+
+        <Typography variant="h6" align="center">
+          Priority: P{priority}
+        </Typography>
+        <center>
+          <form>
+            <Select
+              labelId="priority-select"
+              id="priority-select"
+              value={priority}
+              onChange={event => this.handlePriorityChange(event.target.value)}
+            >
+              <MenuItem value={priorityLevels.P0}>P0</MenuItem>
+              <MenuItem value={priorityLevels.P1}>P1</MenuItem>
+              <MenuItem value={priorityLevels.P2}>P2</MenuItem>
+            </Select>
+          </form>
+        </center>
+
         <List className="anomalies-list">
           {alert.anomalies.map((anomaly, index) => {
             const chartData = {

--- a/frontend/src/AlertsManagement/AlertInfo.test.js
+++ b/frontend/src/AlertsManagement/AlertInfo.test.js
@@ -10,32 +10,44 @@ import * as helpers from './management_helpers';
 
 configure({ adapter: new Adapter() });
 
+// Mock result alert data.
+const expectedAlert = {
+  id: 1987654321098765, 
+  timestampDate: "Fri Dec 27 2019",
+  anomalies: [{ 
+    dataPoints: new Map([ ["2019-10-24", 46] ]), 
+    dimensionName: "Ramen", metricName: "Interest Over Time",
+    timestampDate: "Wed Nov 27 2019",
+    relatedDataList: [{
+      dataPoints: new Map([ ["2019-10-24", 78] ]),
+      dimensionName: "Udon", metricName: "Interest Over Time",
+      username: "bob@",
+      },
+    ]
+  }],
+  priority: priorityLevels.P2,
+  status: "RESOLVED",
+};
+
+const REQUEST_ID = 1987654321098765;
+
+let wrapper;
+
+beforeEach(() => {
+  wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
+  wrapper.setProps({
+    match: {
+      params: {
+        alertId: REQUEST_ID,
+      }
+    },
+    history: {}
+  });
+});
+
 describe("componentDidMount", () => {
-  // Mock result alert data.
-  const expectedAlert = {
-    id: 1987654321098765, 
-    timestampDate: "Fri Dec 27 2019",
-    anomalies: [{ 
-      dataPoints: new Map([ ["2019-10-24", 46] ]), 
-      dimensionName: "Ramen", metricName: "Interest Over Time",
-      timestampDate: "Wed Nov 27 2019"
-    }],
-    priority: priorityLevels.P2,
-    status: "RESOLVED",
-  };
-
-  const REQUEST_ID = 1987654321098765;
-
   it("should set state correctly with fetched alert", async () => {
     const mock = jest.spyOn(helpers, "getSpecificAlertData").mockReturnValue(expectedAlert);
-    const wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
-    wrapper.setProps({
-      match: {
-        params: {
-          alertId: REQUEST_ID,
-        }
-      }
-    });
 
     await wrapper.instance().componentDidMount();
 
@@ -45,14 +57,7 @@ describe("componentDidMount", () => {
 
   it("should throw an error when no data is received", async () => {
     const mock = jest.spyOn(helpers, "getSpecificAlertData").mockReturnValue(null);
-    const wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
-    wrapper.setProps({
-      match: {
-        params: {
-          alertId: REQUEST_ID,
-        }
-      }
-    });
+
     const instance = wrapper.instance();
 
     expect(mock).toHaveBeenCalled();
@@ -62,19 +67,6 @@ describe("componentDidMount", () => {
 })
 
 describe("handleStatusChange", () => {
-  // Mock alert.
-  const expectedAlert = {
-    id: 1987654321098765, 
-    timestampDate: "Fri Dec 27 2019",
-    anomalies: [{ 
-      dataPoints: new Map([ ["2019-10-24", 46] ]), 
-      dimensionName: "Ramen", metricName: "Interest Over Time",
-      timestampDate: "Wed Nov 27 2019"
-    }],
-    priority: priorityLevels.P2,
-    status: "RESOLVED",
-  };
-
   const SERVLET_ROUTE = '/api/v1/alerts-data';
   const POST_DATA = {"body": "1987654321098765 UNRESOLVED", "method": "POST",};
 
@@ -88,7 +80,6 @@ describe("handleStatusChange", () => {
 
   it("sends a POST request with the correct data to change alert status", () => {
     jest.spyOn(global, 'fetch');
-    const wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
     wrapper.setState({ alert: expectedAlert });
 
     act(() => {
@@ -104,19 +95,6 @@ describe("handleStatusChange", () => {
 });
 
 describe("handlePriorityChange", () => {
-  // Mock alert.
-  const expectedAlert = {
-    id: 1987654321098765, 
-    timestampDate: "Fri Dec 27 2019",
-    anomalies: [{ 
-      dataPoints: new Map([ ["2019-10-24", 46] ]), 
-      dimensionName: "Ramen", metricName: "Interest Over Time",
-      timestampDate: "Wed Nov 27 2019"
-    }],
-    priority: priorityLevels.P2,
-    status: "RESOLVED",
-  };
-
   const SERVLET_ROUTE = '/api/v1/alert-visualization';
   const POST_DATA = {"body": "1987654321098765 P1", "method": "POST",};
 
@@ -130,7 +108,6 @@ describe("handlePriorityChange", () => {
 
   it("sends a POST request with the correct data to change alert priority", () => {
     jest.spyOn(global, 'fetch');
-    const wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
     wrapper.setState({ alert: expectedAlert });
 
     act(() => {

--- a/frontend/src/AlertsManagement/AlertInfo.test.js
+++ b/frontend/src/AlertsManagement/AlertInfo.test.js
@@ -5,7 +5,7 @@ import Adapter from 'enzyme-adapter-react-16';
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 import AlertInfo from "./AlertInfo";
-import { UNRESOLVED_STATUS } from './management_constants';
+import { UNRESOLVED_STATUS, priorityLevels } from './management_constants';
 import * as helpers from './management_helpers';
 
 configure({ adapter: new Adapter() });
@@ -20,6 +20,7 @@ describe("componentDidMount", () => {
       dimensionName: "Ramen", metricName: "Interest Over Time",
       timestampDate: "Wed Nov 27 2019"
     }],
+    priority: priorityLevels.P2,
     status: "RESOLVED",
   };
 
@@ -70,6 +71,7 @@ describe("handleStatusChange", () => {
       dimensionName: "Ramen", metricName: "Interest Over Time",
       timestampDate: "Wed Nov 27 2019"
     }],
+    priority: priorityLevels.P2,
     status: "RESOLVED",
   };
 
@@ -96,6 +98,49 @@ describe("handleStatusChange", () => {
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(global.fetch).toHaveBeenCalledWith(SERVLET_ROUTE, POST_DATA);
     expect(wrapper.state('alert').status).toEqual(UNRESOLVED_STATUS);
+  });
+
+  // TODO: write tests for dealing with error response from backend (e.g. 404 code).
+});
+
+describe("handlePriorityChange", () => {
+  // Mock alert.
+  const expectedAlert = {
+    id: 1987654321098765, 
+    timestampDate: "Fri Dec 27 2019",
+    anomalies: [{ 
+      dataPoints: new Map([ ["2019-10-24", 46] ]), 
+      dimensionName: "Ramen", metricName: "Interest Over Time",
+      timestampDate: "Wed Nov 27 2019"
+    }],
+    priority: priorityLevels.P2,
+    status: "RESOLVED",
+  };
+
+  const SERVLET_ROUTE = '/api/v1/alert-visualization';
+  const POST_DATA = {"body": "1987654321098765 P1", "method": "POST",};
+
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends a POST request with the correct data to change alert priority", () => {
+    jest.spyOn(global, 'fetch');
+    const wrapper = shallow(<AlertInfo />, { disableLifecycleMethods: true });
+    wrapper.setState({ alert: expectedAlert });
+
+    act(() => {
+      wrapper.find('#priority-select').simulate('change', { target: { value: priorityLevels.P1 } });
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(SERVLET_ROUTE, POST_DATA);
+    expect(wrapper.state('alert').priority).toEqual(priorityLevels.P1);
+    expect(wrapper.state('priority')).toEqual(priorityLevels.P1);
   });
 
   // TODO: write tests for dealing with error response from backend (e.g. 404 code).

--- a/frontend/src/AlertsManagement/AlertsList.js
+++ b/frontend/src/AlertsManagement/AlertsList.js
@@ -27,12 +27,15 @@ import { formatDate } from '../time_utils';
  */
 export default function AlertsList(props) {
   const [displayAlerts, setDisplayAlerts] = useState(props.displayAlerts);
-  console.log(displayAlerts)
   const allAlerts = props.allAlerts;
   const [priority, setPriority] = useState(priorityLevels.P0);
   const [sortDirectionPriority, setSortDirectionPriority] = useState(false);
   const [sortDirectionDate, setSortDirectionDate] = useState(false);
   
+  useEffect(() =>{
+    setDisplayAlerts(props.displayAlerts);
+  }, [props.displayAlerts]);
+
   const handlePriorityChange = (newPriority, alertId, allAlerts) => {
     const numToEnum = Object.keys(priorityLevels)[Object.values(priorityLevels).indexOf(newPriority)];
     fetch('/api/v1/alert-visualization', {
@@ -42,7 +45,7 @@ export default function AlertsList(props) {
 
     allAlerts.get(alertId).priority = numToEnum;
     // Set state in order to re-render the component, although the state is not used.
-    setPriority(newPriority); 
+    setPriority(priority); 
   }
 
   const sortPriority = (displayAlerts) => {

--- a/frontend/src/AlertsManagement/management_constants.js
+++ b/frontend/src/AlertsManagement/management_constants.js
@@ -10,3 +10,9 @@ export const tabLabels = {
 export const UNRESOLVED_STATUS = "UNRESOLVED";
 export const RESOLVED_STATUS = "RESOLVED";
 export const DEFAULT_ALERTS_LIMIT = 5;
+
+export const priorityLevels = {
+  P0: 0,
+  P1: 1,
+  P2: 2,
+};

--- a/frontend/src/AlertsManagement/management_helpers.js
+++ b/frontend/src/AlertsManagement/management_helpers.js
@@ -33,6 +33,7 @@ export async function getAlertsData(alertsLimit) {
       timestampDate: convertTimestampToDate(alert.timestampDate), 
       anomalies: editedAnomalies,
       status: alert.status,
+      priority: alert.priority,
     });
     
     if (alert.status === UNRESOLVED_STATUS) {
@@ -68,5 +69,6 @@ export async function getSpecificAlertData(alertId) {
     timestampDate: convertTimestampToDate(alert.timestampDate), 
     anomalies: editedAnomalies,
     status: alert.status,
+    priority: alert.priority,
   });
 }

--- a/frontend/src/AlertsManagement/management_helpers.test.js
+++ b/frontend/src/AlertsManagement/management_helpers.test.js
@@ -1,7 +1,7 @@
 import { getAlertsData, getSpecificAlertData } from "./management_helpers";
 import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
-import { DEFAULT_COMMENT_LIMIT } from './management_constants';
+import { DEFAULT_COMMENT_LIMIT, priorityLevels } from './management_constants';
 
 describe("getAlertsData", () => {
   const fakeAlerts = [{
@@ -19,6 +19,7 @@ describe("getAlertsData", () => {
       isPresent: true,
       value: 1234567890123456,
     },
+    priority: priorityLevels.P2,
     status: "UNRESOLVED",
     timestampDate: {date: {year: 2019, month: 12, day: 8}},
   }, 
@@ -33,6 +34,7 @@ describe("getAlertsData", () => {
       isPresent: true,
       value: 1987654321098765,
     },
+    priority: priorityLevels.P1,
     status: "RESOLVED",
     timestampDate: {date: {year: 2019, month: 12, day: 27}},
   }];
@@ -48,6 +50,7 @@ describe("getAlertsData", () => {
       dimensionName: "Ramen", metricName: "Interest Over Time",
       timestampDate: "Sun Dec 01 2019",
     }],
+    priority: priorityLevels.P2,
     status: "UNRESOLVED",
   });
   expectedAlerts.set(1987654321098765, {
@@ -56,6 +59,7 @@ describe("getAlertsData", () => {
       dimensionName: "Ramen", metricName: "Interest Over Time",
       timestampDate: "Wed Nov 27 2019"
     }],
+    priority: priorityLevels.P1,
     status: "RESOLVED",
   });
   const expectedUnchecked = [1234567890123456];
@@ -86,6 +90,7 @@ describe("getSpecificAlertData", () => {
       isPresent: true,
       value: 1987654321098765,
     },
+    priority: priorityLevels.P2,
     status: "RESOLVED",
     timestampDate: {date: {year: 2019, month: 12, day: 27}},
   };
@@ -98,6 +103,7 @@ describe("getSpecificAlertData", () => {
       dimensionName: "Ramen", metricName: "Interest Over Time",
       timestampDate: "Wed Nov 27 2019"
     }],
+    priority: priorityLevels.P2,
     status: "RESOLVED",
   };
 

--- a/frontend/src/NavBar.js
+++ b/frontend/src/NavBar.js
@@ -51,7 +51,7 @@ export default function NavBar() {
           <Typography variant="h6" className={classes.title} component={CustomLink} to="/">
             GreySwan
           </Typography>
-          {isLoggedIn ? 
+          {/* {isLoggedIn ?  */}
             <Fragment>
               <Button color="inherit" id="alerts-button"
                 component={CustomLink} to="/alerts"
@@ -64,7 +64,7 @@ export default function NavBar() {
                 Configs
               </Button>
             </Fragment>
-            : null}
+            {/* : null} */}
           <Button color="inherit" href={logURL} id="login-button">
             {isLoggedIn ? "Logout" :  "Login"}
           </Button>

--- a/frontend/src/NavBar.js
+++ b/frontend/src/NavBar.js
@@ -51,7 +51,7 @@ export default function NavBar() {
           <Typography variant="h6" className={classes.title} component={CustomLink} to="/">
             GreySwan
           </Typography>
-          {/* {isLoggedIn ?  */}
+          {isLoggedIn ? 
             <Fragment>
               <Button color="inherit" id="alerts-button"
                 component={CustomLink} to="/alerts"
@@ -64,7 +64,7 @@ export default function NavBar() {
                 Configs
               </Button>
             </Fragment>
-            {/* : null} */}
+            : null}
           <Button color="inherit" href={logURL} id="login-button">
             {isLoggedIn ? "Logout" :  "Login"}
           </Button>

--- a/frontend/src/time_utils.js
+++ b/frontend/src/time_utils.js
@@ -7,3 +7,20 @@ export function convertTimestampToDate(timestampDate) {
     timestampDate.date.year, timestampDate.date.month - 1, timestampDate.date.day, 0, 0, 0, 0)
     .toDateString();
 }
+
+const DATE_DELIMITER = '/';
+
+/** Format JavaScript date in the form MM/DD/YYYY if mFirst is true, otherwise YYYY/MM/DD. */
+export function formatDate(date, mFirst) {
+  var d = new Date(date),
+      month = '' + (d.getMonth() + 1),
+      day = '' + d.getDate(),
+      year = d.getFullYear();
+
+  if (month.length < 2) 
+      month = '0' + month;
+  if (day.length < 2) 
+      day = '0' + day;
+
+  return mFirst? [month, day, year].join(DATE_DELIMITER) : [year, month, day].join(DATE_DELIMITER);
+}


### PR DESCRIPTION
**Summary**:
1. Add "priority" as a property of the Alert model. To make this change, I also had to change many of the other mock / backend files where alerts are created, which is why there are many files changed in this PR.
2. On the Alerts page, users can change priority of each alert, and also sort the alerts in the list by priority and by date. Here's a short GIF of that working:
![React App (1)](https://user-images.githubusercontent.com/39574893/92123855-11bd8b00-edcb-11ea-9301-765b2492b977.gif)
3. On each individual alert's page, users can also change the priority of each alert. Here's what that looks like:
![Screenshot 2020-09-03 at 9 44 07 AM - Display 2](https://user-images.githubusercontent.com/39574893/92123948-2c8fff80-edcb-11ea-85f1-415ba84d5ed0.png)
4. To change the priority of alerts in the backend, I added a `doPost` method to the Alert Visualization servlet, and this method is called by both the AlertsContent and AlertInfo components in order to change priority of alerts.
5. Tests are added to AlertVisualizationServlet and AlertInfo 